### PR TITLE
V0.18.0

### DIFF
--- a/Ruleset/Configs/ClientConfig.cs
+++ b/Ruleset/Configs/ClientConfig.cs
@@ -18,6 +18,11 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         public bool Music { get; set; } = true;
 
         /// <summary>
+        /// Float, volume from 0.0 to 1.0 for the music.
+        /// </summary>
+        public float MusicVolume { get; set; } = 0.8f;
+
+        /// <summary>
         /// Bool, true if the custom goal horns must be set.
         /// </summary>
         public bool CustomGoalHorns { get; set; } = true;
@@ -26,6 +31,12 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// Bool, true if the refs has to be team color coded.
         /// </summary>
         public bool TeamColor2DRefs { get; set; } = true;
+
+        /// <summary>
+        /// String, full path for the config file.
+        /// </summary>
+        [JsonIgnore]
+        private readonly string _configPath = Path.Combine(Path.GetFullPath("."), Constants.MOD_NAME + "_clientconfig.json");
 
         /// <summary>
         /// Function that serialize the ClientConfig object.
@@ -53,28 +64,35 @@ namespace oomtm450PuckMod_Ruleset.Configs {
             ClientConfig config = new ClientConfig();
 
             try {
-                string rootPath = Path.GetFullPath(".");
-                string configPath = Path.Combine(rootPath, Constants.MOD_NAME + "_clientconfig.json");
-                if (File.Exists(configPath)) {
-                    string configFileContent = File.ReadAllText(configPath);
+                if (File.Exists(config._configPath)) {
+                    string configFileContent = File.ReadAllText(config._configPath);
                     config = SetConfig(configFileContent);
                     Logging.Log($"Client config read.", config, true);
                 }
 
-                try {
-                    File.WriteAllText(configPath, config.ToString());
-                }
-                catch (Exception ex) {
-                    Logging.LogError($"Can't write the client config file. (Permission error ?)\n{ex}");
-                }
-
-                Logging.Log($"Wrote client config : {config}", config, true);
+                config.Save();
             }
             catch (Exception ex) {
                 Logging.LogError($"Can't read the server config file/folder. (Permission error ?)\n{ex}");
             }
 
             return config;
+        }
+
+        internal void Save() {
+            if (string.IsNullOrEmpty(_configPath)) {
+                Logging.LogError($"Can't write the client config file. ({nameof(_configPath)} null or empty)");
+                return;
+            }
+
+            try {
+                File.WriteAllText(_configPath, ToString());
+            }
+            catch (Exception ex) {
+                Logging.LogError($"Can't write the client config file. (Permission error ?)\n{ex}");
+            }
+
+            Logging.Log($"Wrote client config : {ToString()}", this, true);
         }
     }
 }

--- a/Ruleset/Configs/ISubConfig.cs
+++ b/Ruleset/Configs/ISubConfig.cs
@@ -1,0 +1,5 @@
+﻿namespace oomtm450PuckMod_Ruleset.Configs {
+    public interface ISubConfig {
+        void UpdateDefaultValues(ISubConfig oldConfig);
+    }
+}

--- a/Ruleset/Configs/OldServerConfig.cs
+++ b/Ruleset/Configs/OldServerConfig.cs
@@ -1,0 +1,248 @@
+﻿using System.Collections.Generic;
+
+namespace oomtm450PuckMod_Ruleset.Configs {
+    /// <summary>
+    /// Class containing the old configuration from oomtm450_ruleset_serverconfig.json used for this mod.
+    /// </summary>
+    public class OldServerConfig : ISubConfig {
+        #region Properties
+        /// <summary>
+        /// Bool, true if the info logs must be printed.
+        /// </summary>
+        public bool LogInfo { get; } = true;
+
+        /// <summary>
+        /// Bool, true if the custom faceoff (any faceoff not in center) should be used.
+        /// </summary>
+        public bool UseCustomFaceoff { get; } = true;
+
+        /// <summary>
+        /// Bool, true if the height of the puck drop on faceoffs shouldn't be modified.
+        /// </summary>
+        public bool UseDefaultPuckDropHeight { get; } = false;
+
+        /// <summary>
+        /// Float, height of the puck drop on faceoffs.
+        /// </summary>
+        public float PuckDropHeight { get; } = 1.1f;
+
+        /// <summary>
+        /// OldOffsideConfig, config related to offsides.
+        /// </summary>
+        public OldOffsideConfig Offside { get; } = new OldOffsideConfig();
+
+        /// <summary>
+        /// OldIcingConfig, config related to icings.
+        /// </summary>
+        public OldIcingConfig Icing { get; } = new OldIcingConfig();
+
+        /// <summary>
+        /// OldHighStickConfig, config related to high sticks.
+        /// </summary>
+        public OldHighStickConfig HighStick { get; } = new OldHighStickConfig();
+
+        /// <summary>
+        /// OldGIntConfig, config related to goalie interferences.
+        /// </summary>
+        public OldGIntConfig GInt { get; } = new OldGIntConfig();
+
+        /// <summary>
+        /// OldPenaltyConfig, config related to penalties.
+        /// </summary>
+        public OldPenaltyConfig Penalty { get; } = new OldPenaltyConfig();
+
+        /// <summary>
+        /// Int, number of milliseconds for a puck to not be considered tipped by a player's stick.
+        /// </summary>
+        public int MaxTippedMilliseconds { get; } = 90;
+
+        /// <summary>
+        /// Int, number of milliseconds for a possession to be considered with challenge.
+        /// </summary>
+        public int MinPossessionMilliseconds { get; } = 235;
+
+        /// <summary>
+        /// Int, number of milliseconds for a possession to be considered without challenging.
+        /// </summary>
+        public int MaxPossessionMilliseconds { get; } = 500;
+        #endregion
+
+        #region Methods/Functions
+        /// <summary>
+        /// Method that updates this config with the new default values, if the old default values were used.
+        /// </summary>
+        /// <param name="oldConfig">ISubConfig, config with old values.</param>
+        /// <exception cref="System.NotImplementedException">The old configs UpdateDefaultValues are not to be used.</exception>
+        public void UpdateDefaultValues(ISubConfig oldConfig) {
+            throw new System.NotImplementedException();
+        }
+        #endregion
+    }
+
+    /// <summary>
+    /// Class containing the old config for penalties.
+    /// </summary>
+    public class OldPenaltyConfig : ISubConfig {
+        /// <summary>
+        /// Int, interference can be called after this number of milliseconds after touching the puck.
+        /// </summary>
+        public int InterferenceMillisecondsThreshold { get; } = 2000;
+
+        /// <summary>
+        /// Method that updates this config with the new default values, if the old default values were used.
+        /// </summary>
+        /// <param name="oldConfig">ISubConfig, config with old values.</param>
+        /// <exception cref="System.NotImplementedException">The old configs UpdateDefaultValues are not to be used.</exception>
+        public void UpdateDefaultValues(ISubConfig oldConfig) {
+            throw new System.NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// Class containing the old config for offsides.
+    /// </summary>
+    public class OldOffsideConfig : ISubConfig {
+        /// <summary>
+        /// Bool, true if red team offsides are activated.
+        /// </summary>
+        public bool RedTeam { get; } = true;
+
+        /// <summary>
+        /// Bool, true if blue team offsides are activated.
+        /// </summary>
+        public bool BlueTeam { get; } = true;
+
+        /// <summary>
+        /// Method that updates this config with the new default values, if the old default values were used.
+        /// </summary>
+        /// <param name="oldConfig">ISubConfig, config with old values.</param>
+        /// <exception cref="System.NotImplementedException">The old configs UpdateDefaultValues are not to be used.</exception>
+        public void UpdateDefaultValues(ISubConfig oldConfig) {
+            throw new System.NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// Class containing the old config for icings.
+    /// </summary>
+    public class OldIcingConfig : ISubConfig {
+        /// <summary>
+        /// Bool, true if red team icings are activated.
+        /// </summary>
+        public bool RedTeam { get; } = true;
+
+        /// <summary>
+        /// Bool, true if blue team icings are activated.
+        /// </summary>
+        public bool BlueTeam { get; } = true;
+
+        /// <summary>
+        /// Bool, true if deferred icing is activated. If false, icing will be called when the puck is touched.
+        /// </summary>
+        public bool Deferred { get; } = true;
+
+        /// <summary>
+        /// Int, number of milliseconds after puck exiting the stick before arriving behind the goal line to not be considered for icing.
+        /// </summary>
+        public Dictionary<Zone, int> MaxPossibleTime { get; } = new Dictionary<Zone, int> {
+            { Zone.BlueTeam_BehindGoalLine, 8000 },
+            { Zone.RedTeam_BehindGoalLine, 8000 },
+            { Zone.BlueTeam_Zone, 6500 },
+            { Zone.RedTeam_Zone, 6500 },
+            { Zone.BlueTeam_Center, 4500 },
+            { Zone.RedTeam_Center, 4500 },
+        };
+
+        /// <summary>
+        /// Int, number of milliseconds for icing to be called off if it has not being called.
+        /// </summary>
+        public int MaxActiveTime { get; } = 12000;
+
+        /// <summary>
+        /// Method that updates this config with the new default values, if the old default values were used.
+        /// </summary>
+        /// <param name="oldConfig">ISubConfig, config with old values.</param>
+        /// <exception cref="System.NotImplementedException">The old configs UpdateDefaultValues are not to be used.</exception>
+        public void UpdateDefaultValues(ISubConfig oldConfig) {
+            throw new System.NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// Class containing the old config for high sticks.
+    /// </summary>
+    public class OldHighStickConfig : ISubConfig {
+        /// <summary>
+        /// Bool, true if red team high stick are activated.
+        /// </summary>
+        public bool RedTeam { get; } = true;
+
+        /// <summary>
+        /// Bool, true if blue team high stick are activated.
+        /// </summary>
+        public bool BlueTeam { get; } = true;
+
+        /// <summary>
+        /// Float, base height before hitting the puck with a stick is considered high stick.
+        /// </summary>
+        public float MaxHeight { get; } = 1.78f;
+
+        /// <summary>
+        /// Int, number of milliseconds after a high stick to not be considered.
+        /// </summary>
+        public int MaxMilliseconds { get; } = 5000;
+
+        /// <summary>
+        /// Method that updates this config with the new default values, if the old default values were used.
+        /// </summary>
+        /// <param name="oldConfig">ISubConfig, config with old values.</param>
+        /// <exception cref="System.NotImplementedException">The old configs UpdateDefaultValues are not to be used.</exception>
+        public void UpdateDefaultValues(ISubConfig oldConfig) {
+            throw new System.NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// Class containing the old config for goalie interferences.
+    /// </summary>
+    public class OldGIntConfig : ISubConfig {
+        /// <summary>
+        /// Bool, true if red team is able to get their goal called off because of goalie interference.
+        /// </summary>
+        public bool RedTeam { get; } = true;
+
+        /// <summary>
+        /// Bool, true if blue team is able to get their goal called off because of goalie interference.
+        /// </summary>
+        public bool BlueTeam { get; } = true;
+
+        /// <summary>
+        /// Int, number of milliseconds after a push on the goalie to be considered no goal.
+        /// </summary>
+        public int PushNoGoalMilliseconds { get; } = 3500;
+
+        /// <summary>
+        /// Int, number of milliseconds after a hit on the goalie to be considered no goal.
+        /// </summary>
+        public int HitNoGoalMilliseconds { get; } = 9000; // TODO : Remove when penalty is added.
+
+        /// <summary>
+        /// Float, force threshold for a push on the goalie to be considered for goalie interference.
+        /// </summary>
+        public float CollisionForceThreshold { get; } = 0.972f;
+
+        /// <summary>
+        /// Float, radius of a goalie. Make higher to augment the crease size for goalie interference calls.
+        /// </summary>
+        public float GoalieRadius { get; } = 0.784f;
+
+        /// <summary>
+        /// Method that updates this config with the new default values, if the old default values were used.
+        /// </summary>
+        /// <param name="oldConfig">ISubConfig, config with old values.</param>
+        /// <exception cref="System.NotImplementedException">The old configs UpdateDefaultValues are not to be used.</exception>
+        public void UpdateDefaultValues(ISubConfig oldConfig) {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/Ruleset/Configs/OldServerConfig.cs
+++ b/Ruleset/Configs/OldServerConfig.cs
@@ -17,6 +17,12 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         public bool UseCustomFaceoff { get; } = true;
 
         /// <summary>
+        /// Bool, the game rounds down the time remaining on every faceoff.
+        /// This readds 1 second on every faceoff so the game doesn't end too quickly.
+        /// </summary>
+        public bool ReAdd1SecondAfterFaceoff { get; set; } = true;
+
+        /// <summary>
         /// Bool, true if the height of the puck drop on faceoffs shouldn't be modified.
         /// </summary>
         public bool UseDefaultPuckDropHeight { get; } = false;

--- a/Ruleset/Configs/ServerConfig.cs
+++ b/Ruleset/Configs/ServerConfig.cs
@@ -69,7 +69,7 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// <summary>
         /// Int, number of milliseconds for a possession to be considered with challenge.
         /// </summary>
-        public int MinPossessionMilliseconds { get; set; } = 235;
+        public int MinPossessionMilliseconds { get; set; } = 225;
 
         /// <summary>
         /// Int, number of milliseconds for a possession to be considered without challenging.

--- a/Ruleset/Configs/ServerConfig.cs
+++ b/Ruleset/Configs/ServerConfig.cs
@@ -27,6 +27,12 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         public bool UseCustomFaceoff { get; set; } = true;
 
         /// <summary>
+        /// Bool, the game rounds down the time remaining on every faceoff.
+        /// This readds 1 second on every faceoff so the game doesn't end too quickly.
+        /// </summary>
+        public bool ReAdd1SecondAfterFaceoff { get; set; } = true;
+
+        /// <summary>
         /// Bool, true if the height of the puck drop on faceoffs shouldn't be modified.
         /// </summary>
         public bool UseDefaultPuckDropHeight { get; set; } = false;
@@ -94,6 +100,9 @@ namespace oomtm450PuckMod_Ruleset.Configs {
 
             if (UseCustomFaceoff == _oldConfig.UseCustomFaceoff)
                 UseCustomFaceoff = newConfig.UseCustomFaceoff;
+
+            if (ReAdd1SecondAfterFaceoff == _oldConfig.ReAdd1SecondAfterFaceoff)
+                ReAdd1SecondAfterFaceoff = newConfig.ReAdd1SecondAfterFaceoff;
 
             if (UseDefaultPuckDropHeight == _oldConfig.UseDefaultPuckDropHeight)
                 UseDefaultPuckDropHeight = newConfig.UseDefaultPuckDropHeight;

--- a/Ruleset/Configs/ServerConfig.cs
+++ b/Ruleset/Configs/ServerConfig.cs
@@ -57,6 +57,11 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         public GIntConfig GInt { get; set; } = new GIntConfig();
 
         /// <summary>
+        /// PenaltyConfig, config related to penalties.
+        /// </summary>
+        public PenaltyConfig Penalty { get; set; } = new PenaltyConfig();
+
+        /// <summary>
         /// Int, number of milliseconds for a puck to not be considered tipped by a player's stick.
         /// </summary>
         public int MaxTippedMilliseconds { get; set; } = 90;
@@ -123,6 +128,16 @@ namespace oomtm450PuckMod_Ruleset.Configs {
             return config;
         }
         #endregion
+    }
+
+    /// <summary>
+    /// Class containing the config for penalties.
+    /// </summary>
+    public class PenaltyConfig {
+        /// <summary>
+        /// Int, interference can be called after this number of milliseconds after touching the puck.
+        /// </summary>
+        public int InterferenceMillisecondsThreshold { get; set; } = 2000;
     }
 
     /// <summary>

--- a/Ruleset/Configs/ServerConfig.cs
+++ b/Ruleset/Configs/ServerConfig.cs
@@ -5,9 +5,9 @@ using System.IO;
 
 namespace oomtm450PuckMod_Ruleset.Configs {
     /// <summary>
-    /// Class containing the configuration from oomtm450_template_serverconfig.json used for this mod.
+    /// Class containing the configuration from oomtm450_ruleset_serverconfig.json used for this mod.
     /// </summary>
-    public class ServerConfig : IConfig {
+    public class ServerConfig : IConfig, ISubConfig {
         #region Constants
         /// <summary>
         /// Const string, name used when sending the config data to the client.
@@ -79,6 +79,45 @@ namespace oomtm450PuckMod_Ruleset.Configs {
 
         #region Methods/Functions
         /// <summary>
+        /// Method that updates this config with the new default values, if the old default values were used.
+        /// </summary>
+        /// <param name="oldConfig">ISubConfig, config with old values.</param>
+        public void UpdateDefaultValues(ISubConfig oldConfig) {
+            if (!(oldConfig is OldServerConfig))
+                throw new ArgumentException($"oldConfig has to be typeof {nameof(OldServerConfig)}.", nameof(oldConfig));
+
+            OldServerConfig _oldConfig = oldConfig as OldServerConfig;
+            ServerConfig newConfig = new ServerConfig();
+
+            if (LogInfo == _oldConfig.LogInfo)
+                LogInfo = newConfig.LogInfo;
+
+            if (UseCustomFaceoff == _oldConfig.UseCustomFaceoff)
+                UseCustomFaceoff = newConfig.UseCustomFaceoff;
+
+            if (UseDefaultPuckDropHeight == _oldConfig.UseDefaultPuckDropHeight)
+                UseDefaultPuckDropHeight = newConfig.UseDefaultPuckDropHeight;
+
+            if (PuckDropHeight == _oldConfig.PuckDropHeight)
+                PuckDropHeight = newConfig.PuckDropHeight;
+
+            if (MaxTippedMilliseconds == _oldConfig.MaxTippedMilliseconds)
+                MaxTippedMilliseconds = newConfig.MaxTippedMilliseconds;
+
+            if (MinPossessionMilliseconds == _oldConfig.MinPossessionMilliseconds)
+                MinPossessionMilliseconds = newConfig.MinPossessionMilliseconds;
+
+            if (MaxPossessionMilliseconds == _oldConfig.MaxPossessionMilliseconds)
+                MaxPossessionMilliseconds = newConfig.MaxPossessionMilliseconds;
+
+            Offside.UpdateDefaultValues(_oldConfig.Offside);
+            Icing.UpdateDefaultValues(_oldConfig.Icing);
+            HighStick.UpdateDefaultValues(_oldConfig.HighStick);
+            GInt.UpdateDefaultValues(_oldConfig.GInt);
+            Penalty.UpdateDefaultValues(_oldConfig.Penalty);
+        }
+
+        /// <summary>
         /// Function that serialize the config object.
         /// </summary>
         /// <returns>String, serialized config.</returns>
@@ -112,6 +151,8 @@ namespace oomtm450PuckMod_Ruleset.Configs {
                     Logging.Log($"Server config read.", config, true);
                 }
 
+                config.UpdateDefaultValues(new OldServerConfig());
+
                 try {
                     File.WriteAllText(configPath, config.ToString());
                 }
@@ -133,41 +174,74 @@ namespace oomtm450PuckMod_Ruleset.Configs {
     /// <summary>
     /// Class containing the config for penalties.
     /// </summary>
-    public class PenaltyConfig {
+    public class PenaltyConfig : ISubConfig {
         /// <summary>
         /// Int, interference can be called after this number of milliseconds after touching the puck.
         /// </summary>
         public int InterferenceMillisecondsThreshold { get; set; } = 2000;
+
+        /// <summary>
+        /// Method that updates this config with the new default values, if the old default values were used.
+        /// </summary>
+        /// <param name="oldConfig">ISubConfig, config with old values.</param>
+        public void UpdateDefaultValues(ISubConfig oldConfig) {
+            if (!(oldConfig is OldPenaltyConfig))
+                throw new ArgumentException($"oldConfig has to be typeof {nameof(OldPenaltyConfig)}.", nameof(oldConfig));
+
+            OldPenaltyConfig _oldConfig = oldConfig as OldPenaltyConfig;
+            PenaltyConfig newConfig = new PenaltyConfig();
+
+            if (InterferenceMillisecondsThreshold == _oldConfig.InterferenceMillisecondsThreshold)
+                InterferenceMillisecondsThreshold = newConfig.InterferenceMillisecondsThreshold;
+        }
     }
 
     /// <summary>
     /// Class containing the config for offsides.
     /// </summary>
-    public class OffsideConfig {
+    public class OffsideConfig : ISubConfig {
+        /// <summary>
+        /// Bool, true if blue team offsides are activated.
+        /// </summary>
+        public bool BlueTeam { get; set; } = true;
+
         /// <summary>
         /// Bool, true if red team offsides are activated.
         /// </summary>
         public bool RedTeam { get; set; } = true;
 
         /// <summary>
-        /// Bool, true if blue team offsides are activated.
+        /// Method that updates this config with the new default values, if the old default values were used.
         /// </summary>
-        public bool BlueTeam { get; set; } = true;
+        /// <param name="oldConfig">ISubConfig, config with old values.</param>
+        public void UpdateDefaultValues(ISubConfig oldConfig) {
+            if (!(oldConfig is OldOffsideConfig))
+                throw new ArgumentException($"oldConfig has to be typeof {nameof(OldOffsideConfig)}.", nameof(oldConfig));
+
+            OldOffsideConfig _oldConfig = oldConfig as OldOffsideConfig;
+            OffsideConfig newConfig = new OffsideConfig();
+
+            if (BlueTeam == _oldConfig.BlueTeam)
+                BlueTeam = newConfig.BlueTeam;
+
+            if (RedTeam == _oldConfig.RedTeam)
+                RedTeam = newConfig.RedTeam;
+        }
     }
 
     /// <summary>
     /// Class containing the config for icings.
     /// </summary>
-    public class IcingConfig {
-        /// <summary>
-        /// Bool, true if red team icings are activated.
-        /// </summary>
-        public bool RedTeam { get; set; } = true;
-
+    public class IcingConfig : ISubConfig {
         /// <summary>
         /// Bool, true if blue team icings are activated.
         /// </summary>
         public bool BlueTeam { get; set; } = true;
+
+        /// <summary>
+        /// Bool, true if red team icings are activated.
+        /// </summary>
+        public bool RedTeam { get; set; } = true;
 
         /// <summary>
         /// Bool, true if deferred icing is activated. If false, icing will be called when the puck is touched.
@@ -190,21 +264,53 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// Int, number of milliseconds for icing to be called off if it has not being called.
         /// </summary>
         public int MaxActiveTime { get; set; } = 12000;
+
+        /// <summary>
+        /// Method that updates this config with the new default values, if the old default values were used.
+        /// </summary>
+        /// <param name="oldConfig">ISubConfig, config with old values.</param>
+        public void UpdateDefaultValues(ISubConfig oldConfig) {
+            if (!(oldConfig is OldIcingConfig))
+                throw new ArgumentException($"oldConfig has to be typeof {nameof(OldIcingConfig)}.", nameof(oldConfig));
+
+            OldIcingConfig _oldConfig = oldConfig as OldIcingConfig;
+            IcingConfig newConfig = new IcingConfig();
+
+            if (BlueTeam == _oldConfig.BlueTeam)
+                BlueTeam = newConfig.BlueTeam;
+
+            if (RedTeam == _oldConfig.RedTeam)
+                RedTeam = newConfig.RedTeam;
+
+            if (Deferred == _oldConfig.Deferred)
+                Deferred = newConfig.Deferred;
+
+            try {
+                foreach (KeyValuePair<Zone, int> kvp in new Dictionary<Zone, int>(MaxPossibleTime)) {
+                    if (_oldConfig.MaxPossibleTime.TryGetValue(kvp.Key, out int value) && value == kvp.Value)
+                        MaxPossibleTime[kvp.Key] = newConfig.MaxPossibleTime[kvp.Key];
+                }
+            }
+            catch { }
+
+            if (MaxActiveTime == _oldConfig.MaxActiveTime)
+                MaxActiveTime = newConfig.MaxActiveTime;
+        }
     }
 
     /// <summary>
     /// Class containing the config for high sticks.
     /// </summary>
-    public class HighStickConfig {
-        /// <summary>
-        /// Bool, true if red team high stick are activated.
-        /// </summary>
-        public bool RedTeam { get; set; } = true;
-
+    public class HighStickConfig : ISubConfig {
         /// <summary>
         /// Bool, true if blue team high stick are activated.
         /// </summary>
         public bool BlueTeam { get; set; } = true;
+
+        /// <summary>
+        /// Bool, true if red team high stick are activated.
+        /// </summary>
+        public bool RedTeam { get; set; } = true;
 
         /// <summary>
         /// Float, base height before hitting the puck with a stick is considered high stick.
@@ -215,21 +321,45 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// Int, number of milliseconds after a high stick to not be considered.
         /// </summary>
         public int MaxMilliseconds { get; set; } = 5000;
+
+        /// <summary>
+        /// Method that updates this config with the new default values, if the old default values were used.
+        /// </summary>
+        /// <param name="oldConfig">ISubConfig, config with old values.</param>
+        public void UpdateDefaultValues(ISubConfig oldConfig) {
+            if (!(oldConfig is OldHighStickConfig))
+                throw new ArgumentException($"oldConfig has to be typeof {nameof(OldHighStickConfig)}.", nameof(oldConfig));
+
+            OldHighStickConfig _oldConfig = oldConfig as OldHighStickConfig;
+            HighStickConfig newConfig = new HighStickConfig();
+
+            if (BlueTeam == _oldConfig.BlueTeam)
+                BlueTeam = newConfig.BlueTeam;
+
+            if (RedTeam == _oldConfig.RedTeam)
+                RedTeam = newConfig.RedTeam;
+
+            if (MaxHeight == _oldConfig.MaxHeight)
+                MaxHeight = newConfig.MaxHeight;
+
+            if (MaxMilliseconds == _oldConfig.MaxMilliseconds)
+                MaxMilliseconds = newConfig.MaxMilliseconds;
+        }
     }
 
     /// <summary>
     /// Class containing the config for goalie interferences.
     /// </summary>
-    public class GIntConfig {
-        /// <summary>
-        /// Bool, true if red team is able to get their goal called off because of goalie interference.
-        /// </summary>
-        public bool RedTeam { get; set; } = true;
-
+    public class GIntConfig : ISubConfig {
         /// <summary>
         /// Bool, true if blue team is able to get their goal called off because of goalie interference.
         /// </summary>
         public bool BlueTeam { get; set; } = true;
+
+        /// <summary>
+        /// Bool, true if red team is able to get their goal called off because of goalie interference.
+        /// </summary>
+        public bool RedTeam { get; set; } = true;
 
         /// <summary>
         /// Int, number of milliseconds after a push on the goalie to be considered no goal.
@@ -250,5 +380,35 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// Float, radius of a goalie. Make higher to augment the crease size for goalie interference calls.
         /// </summary>
         public float GoalieRadius { get; set; } = 0.784f;
+
+        /// <summary>
+        /// Method that updates this config with the new default values, if the old default values were used.
+        /// </summary>
+        /// <param name="oldConfig">ISubConfig, config with old values.</param>
+        public void UpdateDefaultValues(ISubConfig oldConfig) {
+            if (!(oldConfig is OldGIntConfig))
+                throw new ArgumentException($"oldConfig has to be typeof {nameof(OldGIntConfig)}.", nameof(oldConfig));
+
+            OldGIntConfig _oldConfig = oldConfig as OldGIntConfig;
+            GIntConfig newConfig = new GIntConfig();
+
+            if (BlueTeam == _oldConfig.BlueTeam)
+                BlueTeam = newConfig.BlueTeam;
+
+            if (RedTeam == _oldConfig.RedTeam)
+                RedTeam = newConfig.RedTeam;
+
+            if (PushNoGoalMilliseconds == _oldConfig.PushNoGoalMilliseconds)
+                PushNoGoalMilliseconds = newConfig.PushNoGoalMilliseconds;
+
+            if (HitNoGoalMilliseconds == _oldConfig.HitNoGoalMilliseconds)
+                HitNoGoalMilliseconds = newConfig.HitNoGoalMilliseconds;
+
+            if (CollisionForceThreshold == _oldConfig.CollisionForceThreshold)
+                CollisionForceThreshold = newConfig.CollisionForceThreshold;
+
+            if (GoalieRadius == _oldConfig.GoalieRadius)
+                GoalieRadius = newConfig.GoalieRadius;
+        }
     }
 }

--- a/Ruleset/Configs/ServerConfig.cs
+++ b/Ruleset/Configs/ServerConfig.cs
@@ -64,7 +64,7 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// <summary>
         /// Int, number of milliseconds for a puck to not be considered tipped by a player's stick.
         /// </summary>
-        public int MaxTippedMilliseconds { get; set; } = 90;
+        public int MaxTippedMilliseconds { get; set; } = 91;
 
         /// <summary>
         /// Int, number of milliseconds for a possession to be considered with challenge.

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -23,7 +23,7 @@ namespace oomtm450PuckMod_Ruleset {
         /// <summary>
         /// Const string, version of the mod.
         /// </summary>
-        private static readonly string MOD_VERSION = "0.18.0DEV";
+        private static readonly string MOD_VERSION = "0.18.0DEV2";
 
         /// <summary>
         /// Const float, radius of the puck.
@@ -1186,8 +1186,8 @@ namespace oomtm450PuckMod_Ruleset {
                         }
                         else if (isHighStick) {
                             _nextFaceoffSpot = Faceoff.GetNextFaceoffPosition(playerTeam, false, _puckLastStateBeforeCall[Rule.HighStick]);
-                            UIChat.Instance.Server_SendSystemChatMessage($"HIGH STICK {playerTeam.ToString().ToUpperInvariant()} TEAM CALLED");
                             NetworkCommunication.SendDataToAll(RefSignals.GetSignalConstant(false, playerTeam), RefSignals.HIGHSTICK_LINESMAN, Constants.FROM_SERVER, _serverConfig, false);
+                            UIChat.Instance.Server_SendSystemChatMessage($"HIGH STICK {playerTeam.ToString().ToUpperInvariant()} TEAM CALLED");
                             NetworkCommunication.SendDataToAll(RefSignals.GetSignalConstant(true, playerTeam), RefSignals.HIGHSTICK_REF, Constants.FROM_SERVER, _serverConfig, false);
                         }
                         else if (isGoalieInt) {

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -664,11 +664,16 @@ namespace oomtm450PuckMod_Ruleset {
                         NetworkCommunication.SendDataToAll(Sounds.PLAY_SOUND, Sounds.FormatSoundStrForCommunication(_currentMusicPlaying), Constants.FROM_SERVER, _serverConfig);
                     }
                     else if (phase == GamePhase.PeriodOver) {
+                        _nextFaceoffSpot = FaceoffSpot.Center; // Fix faceoff if the period is over because of deferred icing.
+
+                        NetworkCommunication.SendDataToAll(RefSignals.STOP_SIGNAL_BLUE, RefSignals.ALL, Constants.FROM_SERVER, _serverConfig, false);
+                        NetworkCommunication.SendDataToAll(RefSignals.STOP_SIGNAL_RED, RefSignals.ALL, Constants.FROM_SERVER, _serverConfig, false);
+
                         _currentMusicPlaying = Sounds.BETWEEN_PERIODS_MUSIC;
                         NetworkCommunication.SendDataToAll(Sounds.PLAY_SOUND, Sounds.FormatSoundStrForCommunication(_currentMusicPlaying), Constants.FROM_SERVER, _serverConfig);
                     }
-                    else if (phase == GamePhase.FaceOff || phase == GamePhase.Warmup || phase == GamePhase.GameOver || phase == GamePhase.PeriodOver) {
-                        if (phase == GamePhase.GameOver || phase == GamePhase.PeriodOver) // Fix faceoff if the period is over because of deferred icing.
+                    else if (phase == GamePhase.FaceOff || phase == GamePhase.Warmup || phase == GamePhase.GameOver) {
+                        if (phase == GamePhase.GameOver) // Fix faceoff if the period is over because of deferred icing.
                             _nextFaceoffSpot = FaceoffSpot.Center;
 
                         // Reset players zone.

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -729,7 +729,7 @@ namespace oomtm450PuckMod_Ruleset {
                     }
 
                     if (!_changedPhase) {
-                        if (string.IsNullOrEmpty(_currentMusicPlaying)) {
+                        if (string.IsNullOrEmpty(_currentMusicPlaying) || _currentMusicPlaying == Sounds.WARMUP_MUSIC) {
                             NetworkCommunication.SendDataToAll(Sounds.STOP_SOUND, Sounds.ALL, Constants.FROM_SERVER, _serverConfig);
 
                             if (phase == GamePhase.FaceOff) {

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -180,6 +180,11 @@ namespace oomtm450PuckMod_Ruleset {
             { PlayerTeam.Red, "" },
         };
 
+        /// <summary>
+        /// LockDictionary of string and (PlayerTeam and DateTime), dictionary of all DateTime of every player last puck touch.
+        /// </summary>
+        private static readonly LockDictionary<string, (PlayerTeam Team, DateTime LastTouchDateTime)> _playersOnPuckTipIncludedDateTime = new LockDictionary<string, (PlayerTeam, DateTime)>();
+
         private static readonly LockDictionary<PlayerTeam, bool> _lastShotWasCounted = new LockDictionary<PlayerTeam, bool> {
             { PlayerTeam.Blue, true },
             { PlayerTeam.Red, true },
@@ -434,6 +439,7 @@ namespace oomtm450PuckMod_Ruleset {
 
                     _lastPlayerOnPuckTeamTipIncluded = stick.Player.Team.Value;
                     _lastPlayerOnPuckTipIncludedSteamId[stick.Player.Team.Value] = playerSteamId;
+                    _playersOnPuckTipIncludedDateTime.AddOrUpdate(playerSteamId, (stick.Player.Team.Value, DateTime.UtcNow));
 
                     if (!_playersLastTimePuckPossession.TryGetValue(playerSteamId, out Stopwatch watch)) {
                         watch = new Stopwatch();
@@ -521,6 +527,7 @@ namespace oomtm450PuckMod_Ruleset {
 
                     _lastPlayerOnPuckTeamTipIncluded = stick.Player.Team.Value;
                     _lastPlayerOnPuckTipIncludedSteamId[stick.Player.Team.Value] = currentPlayerSteamId;
+                    _playersOnPuckTipIncludedDateTime.AddOrUpdate(currentPlayerSteamId, (stick.Player.Team.Value, DateTime.UtcNow));
 
                     // Icing logic.
                     bool icingPossible = false;
@@ -705,6 +712,8 @@ namespace oomtm450PuckMod_Ruleset {
 
                         foreach (PlayerTeam key in new List<PlayerTeam>(_lastPlayerOnPuckTipIncludedSteamId.Keys))
                             _lastPlayerOnPuckTipIncludedSteamId[key] = "";
+
+                        _playersOnPuckTipIncludedDateTime.Clear();
 
                         NetworkCommunication.SendDataToAll(RefSignals.STOP_SIGNAL_BLUE, RefSignals.ALL, Constants.FROM_SERVER, _serverConfig, false);
                         NetworkCommunication.SendDataToAll(RefSignals.STOP_SIGNAL_RED, RefSignals.ALL, Constants.FROM_SERVER, _serverConfig, false);

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -719,7 +719,7 @@ namespace oomtm450PuckMod_Ruleset {
                         NetworkCommunication.SendDataToAll(RefSignals.STOP_SIGNAL_RED, RefSignals.ALL, Constants.FROM_SERVER, _serverConfig, false);
                     }
                     else if (phase == GamePhase.Playing) {
-                        if (time == -1)
+                        if (time == -1 && _serverConfig.ReAdd1SecondAfterFaceoff)
                             time = GetPrivateField<int>(typeof(GameManager), GameManager.Instance, "remainingPlayTime") + 1;
                     }
 
@@ -765,7 +765,8 @@ namespace oomtm450PuckMod_Ruleset {
 
                     if (phase == GamePhase.Playing) {
                         _changedPhase = false;
-                        time = _periodTimeRemaining + 1;
+                        if (_serverConfig.ReAdd1SecondAfterFaceoff)
+                            time = _periodTimeRemaining + 1;
                     }
                 }
                 catch (Exception ex) {

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -1187,7 +1187,7 @@ namespace oomtm450PuckMod_Ruleset {
                         else if (isHighStick) {
                             _nextFaceoffSpot = Faceoff.GetNextFaceoffPosition(playerTeam, false, _puckLastStateBeforeCall[Rule.HighStick]);
                             UIChat.Instance.Server_SendSystemChatMessage($"HIGH STICK {playerTeam.ToString().ToUpperInvariant()} TEAM CALLED");
-                            NetworkCommunication.SendDataToAll(RefSignals.GetSignalConstant(false, playerTeam), RefSignals.OFFSIDE_LINESMAN, Constants.FROM_SERVER, _serverConfig, false);
+                            NetworkCommunication.SendDataToAll(RefSignals.GetSignalConstant(false, playerTeam), RefSignals.HIGHSTICK_LINESMAN, Constants.FROM_SERVER, _serverConfig, false);
                             NetworkCommunication.SendDataToAll(RefSignals.GetSignalConstant(true, playerTeam), RefSignals.HIGHSTICK_REF, Constants.FROM_SERVER, _serverConfig, false);
                         }
                         else if (isGoalieInt) {

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -23,7 +23,7 @@ namespace oomtm450PuckMod_Ruleset {
         /// <summary>
         /// Const string, version of the mod.
         /// </summary>
-        private static readonly string MOD_VERSION = "0.18.0DEV4";
+        private static readonly string MOD_VERSION = "0.18.0";
 
         /// <summary>
         /// Const float, radius of the puck.

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -23,7 +23,7 @@ namespace oomtm450PuckMod_Ruleset {
         /// <summary>
         /// Const string, version of the mod.
         /// </summary>
-        private static readonly string MOD_VERSION = "0.17.0";
+        private static readonly string MOD_VERSION = "0.18.0DEV";
 
         /// <summary>
         /// Const float, radius of the puck.

--- a/Ruleset/Sounds.cs
+++ b/Ruleset/Sounds.cs
@@ -99,6 +99,11 @@ namespace oomtm450PuckMod_Ruleset {
             Destroy(gameObject);
         }
 
+        /// <summary>
+        /// Function that downloads the streamed audio clips from the mods' folder using WebRequest locally.
+        /// </summary>
+        /// <param name="path">String, full path to the directory containing the sounds to load.</param>
+        /// <returns>IEnumerator, enumerator used by the Coroutine to load the audio clips.</returns>
         private IEnumerator GetAudioClips(string path) {
             if (_audioClips.Count == 0 && Ruleset._clientConfig.Music) {
                 foreach (string file in Directory.GetFiles(path, "*" + SOUND_EXTENSION, SearchOption.AllDirectories)) {

--- a/Ruleset/Sounds.cs
+++ b/Ruleset/Sounds.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
+using UnityEngine.Audio;
 using UnityEngine.Networking;
 
 namespace oomtm450PuckMod_Ruleset {
@@ -45,6 +46,8 @@ namespace oomtm450PuckMod_Ruleset {
         #region Fields
         private readonly LockDictionary<string, GameObject> _soundObjects = new LockDictionary<string, GameObject>();
         private readonly List<AudioClip> _audioClips = new List<AudioClip>();
+
+        private AudioSource _currentAudioSource = null;
         #endregion
 
         #region Properties
@@ -149,7 +152,7 @@ namespace oomtm450PuckMod_Ruleset {
                 SetGoalHorns();
         }
 
-        internal void Play(string name, float delay = 0, bool loop = false) {
+        internal void Play(string name, string type, float delay = 0, bool loop = false) {
             if (string.IsNullOrEmpty(name))
                 return;
 
@@ -168,7 +171,16 @@ namespace oomtm450PuckMod_Ruleset {
 
             AudioSource audioSource = soundObject.GetComponent<AudioSource>();
             audioSource.loop = loop;
-            audioSource.volume = SettingsManager.Instance.GlobalVolume;
+
+            if (type == MUSIC) {
+                _currentAudioSource = audioSource;
+                ChangeMusicVolume();
+            }
+            else {
+                _currentAudioSource = null;
+                audioSource.volume = SettingsManager.Instance.GlobalVolume * SettingsManager.Instance.GameVolume;
+            }
+
             if (delay == 0)
                 audioSource.Play();
             else
@@ -187,6 +199,13 @@ namespace oomtm450PuckMod_Ruleset {
         internal void StopAll() {
             foreach (GameObject soundObject in _soundObjects.Values)
                 soundObject.GetComponent<AudioSource>().Stop();
+        }
+
+        internal void ChangeMusicVolume() {
+            if (_currentAudioSource == null)
+                return;
+
+            _currentAudioSource.volume = SettingsManager.Instance.GlobalVolume * Ruleset._clientConfig.MusicVolume;
         }
 
         internal static string GetRandomSound(List<string> musicList, int? seed = null) {

--- a/Ruleset/SystemFunc/LockDictionary.cs
+++ b/Ruleset/SystemFunc/LockDictionary.cs
@@ -55,6 +55,15 @@ namespace oomtm450PuckMod_Ruleset {
                 _dictionary.Add(key, value);
         }
 
+        public void AddOrUpdate(TKey key, TValue value) {
+            lock (_locker) {
+                if (_dictionary.ContainsKey(key))
+                    _dictionary[key] = value;
+                else
+                    _dictionary.Add(key, value);
+            }
+        }
+
         public bool Remove(TKey key) {
             lock (_locker)
                 return _dictionary.Remove(key);


### PR DESCRIPTION
Added config for 1 second re-added on all faceoffs.
Added music volume using the chat command : /musicvol (0-100).
Fixed faceoff music after warmup.
Fixed faceoff position on period start.
Fixed ref signals overlapping.
Adjusted possession values.
Adjusted tip values.
Implemented config auto-update.
Reduced mod size.