### PR TITLE
Ajout de scripts de setup

### DIFF
--- a/Scripts/FixReferences.ps1
+++ b/Scripts/FixReferences.ps1
@@ -1,0 +1,215 @@
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$CSProjFilePath,
+
+    [Parameter(Mandatory = $true, Position = 1)]
+    [string]$PuckPath
+)
+
+# Hardcoded list of package name substrings to look for
+# Hardcoded list of Reference Include attributes where HintPath starts with G:\SteamLibrary
+$packages = @(
+    "0Harmony",
+    "Assembly-CSharp-firstpass",
+    "AYellowpaper.SerializedCollections",
+    "com.rlabrecque.steamworks.net",
+    "DebugGUI",
+    "DOTween",
+    "DOTween.Modules",
+    "Linework",
+    "Microsoft.Bcl.AsyncInterfaces",
+    "Mono.Cecil.Pdb",
+    "Mono.Cecil.Rocks",
+    "Mono.Security",
+    "MonoMod.RuntimeDetour",
+    "MonoMod.Utils",
+    "Newtonsoft.Json",
+    "Open.Nat",
+    "Puck",
+    "SingularityGroup.HotReload.Runtime",
+    "SingularityGroup.HotReload.Runtime.Public",
+    "SocketIO.Core",
+    "SocketIO.Serializer.Core",
+    "SocketIO.Serializer.SystemTextJson",
+    "SocketIOClient",
+    "System.ComponentModel.Composition",
+    "System.EnterpriseServices",
+    "System.ServiceModel.Internals",
+    "Unity.Burst",
+    "Unity.Burst.Unsafe",
+    "Unity.Collections",
+    "Unity.Collections.LowLevel.ILSupport",
+    "Unity.InputSystem",
+    "Unity.InputSystem.ForUI",
+    "Unity.Mathematics",
+    "Unity.MemoryProfiler",
+    "Unity.Multiplayer.Center.Common",
+    "Unity.Multiplayer.Tools.Adapters",
+    "Unity.Multiplayer.Tools.Adapters.Ngo1",
+    "Unity.Multiplayer.Tools.Adapters.Ngo1WithUtp2",
+    "Unity.Multiplayer.Tools.Adapters.Utp2",
+    "Unity.Multiplayer.Tools.Common",
+    "Unity.Multiplayer.Tools.Initialization",
+    "Unity.Multiplayer.Tools.MetricEvents",
+    "Unity.Multiplayer.Tools.MetricTestData",
+    "Unity.Multiplayer.Tools.MetricTypes",
+    "Unity.Multiplayer.Tools.NetStats",
+    "Unity.Multiplayer.Tools.NetStatsMonitor.Component",
+    "Unity.Multiplayer.Tools.NetStatsMonitor.Configuration",
+    "Unity.Multiplayer.Tools.NetStatsMonitor.Implementation",
+    "Unity.Multiplayer.Tools.NetStatsReporting",
+    "Unity.Multiplayer.Tools.NetVis.Configuration",
+    "Unity.Multiplayer.Tools.NetworkProfiler.Runtime",
+    "Unity.Multiplayer.Tools.NetworkSimulator.Runtime",
+    "Unity.Multiplayer.Tools.NetworkSolutionInterface",
+    "Unity.Netcode.Runtime",
+    "Unity.Networking.Transport",
+    "Unity.PlayerPrefsEditor.Samples.SampleScene",
+    "Unity.Profiling.Core",
+    "Unity.Rendering.LightTransport.Runtime",
+    "Unity.RenderPipeline.Universal.ShaderLibrary",
+    "Unity.RenderPipelines.Core.Runtime",
+    "Unity.RenderPipelines.Core.Runtime.Shared",
+    "Unity.RenderPipelines.Core.ShaderLibrary",
+    "Unity.RenderPipelines.GPUDriven.Runtime",
+    "Unity.RenderPipelines.ShaderGraph.ShaderGraphLibrary",
+    "Unity.RenderPipelines.Universal.2D.Runtime",
+    "Unity.RenderPipelines.Universal.Config.Runtime",
+    "Unity.RenderPipelines.Universal.Runtime",
+    "Unity.RenderPipelines.Universal.Shaders",
+    "Unity.Splines",
+    "Unity.TextMeshPro",
+    "UnityEngine",
+    "UnityEngine.AccessibilityModule",
+    "UnityEngine.AIModule",
+    "UnityEngine.AMDModule",
+    "UnityEngine.AndroidJNIModule",
+    "UnityEngine.AnimationModule",
+    "UnityEngine.ARModule",
+    "UnityEngine.AssetBundleModule",
+    "UnityEngine.AudioModule",
+    "UnityEngine.ClothModule",
+    "UnityEngine.ClusterInputModule",
+    "UnityEngine.ClusterRendererModule",
+    "UnityEngine.ContentLoadModule",
+    "UnityEngine.CoreModule",
+    "UnityEngine.CrashReportingModule",
+    "UnityEngine.DirectorModule",
+    "UnityEngine.DSPGraphModule",
+    "UnityEngine.GameCenterModule",
+    "UnityEngine.GIModule",
+    "UnityEngine.GraphicsStateCollectionSerializerModule",
+    "UnityEngine.GridModule",
+    "UnityEngine.HierarchyCoreModule",
+    "UnityEngine.HotReloadModule",
+    "UnityEngine.ImageConversionModule",
+    "UnityEngine.IMGUIModule",
+    "UnityEngine.InputForUIModule",
+    "UnityEngine.InputLegacyModule",
+    "UnityEngine.InputModule",
+    "UnityEngine.JSONSerializeModule",
+    "UnityEngine.LocalizationModule",
+    "UnityEngine.MarshallingModule",
+    "UnityEngine.MultiplayerModule",
+    "UnityEngine.NVIDIAModule",
+    "UnityEngine.ParticleSystemModule",
+    "UnityEngine.PerformanceReportingModule",
+    "UnityEngine.Physics2DModule",
+    "UnityEngine.PhysicsModule",
+    "UnityEngine.PropertiesModule",
+    "UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule",
+    "UnityEngine.ScreenCaptureModule",
+    "UnityEngine.ShaderVariantAnalyticsModule",
+    "UnityEngine.SharedInternalsModule",
+    "UnityEngine.SpriteMaskModule",
+    "UnityEngine.SpriteShapeModule",
+    "UnityEngine.StreamingModule",
+    "UnityEngine.SubstanceModule",
+    "UnityEngine.SubsystemsModule",
+    "UnityEngine.TerrainModule",
+    "UnityEngine.TerrainPhysicsModule",
+    "UnityEngine.TextCoreFontEngineModule",
+    "UnityEngine.TextCoreTextEngineModule",
+    "UnityEngine.TextRenderingModule",
+    "UnityEngine.TilemapModule",
+    "UnityEngine.TLSModule",
+    "UnityEngine.UI",
+    "UnityEngine.UIElementsModule",
+    "UnityEngine.UIModule",
+    "UnityEngine.UmbraModule",
+    "UnityEngine.UnityAnalyticsCommonModule",
+    "UnityEngine.UnityAnalyticsModule",
+    "UnityEngine.UnityConnectModule",
+    "UnityEngine.UnityCurlModule",
+    "UnityEngine.UnityTestProtocolModule",
+    "UnityEngine.UnityWebRequestAssetBundleModule",
+    "UnityEngine.UnityWebRequestAudioModule",
+    "UnityEngine.UnityWebRequestModule",
+    "UnityEngine.UnityWebRequestTextureModule",
+    "UnityEngine.UnityWebRequestWWWModule",
+    "UnityEngine.VehiclesModule",
+    "UnityEngine.VFXModule",
+    "UnityEngine.VideoModule",
+    "UnityEngine.VirtualTexturingModule",
+    "UnityEngine.VRModule",
+    "UnityEngine.WindModule",
+    "UnityEngine.XRModule",
+    "uPnP"
+)
+
+if (-not (Test-Path -Path $CSProjFilePath)) {
+    Write-Error "File not found: $CSProjFilePath"
+    exit 1
+}
+
+# Load XML
+[xml]$doc = Get-Content -Path $CSProjFilePath -Raw
+
+# Ensure backup
+$bakPath = "$CSProjFilePath.bak"
+Copy-Item -Path $CSProjFilePath -Destination $bakPath -Force
+
+# Get all ItemGroup nodes (works with or without MSBuild default namespace)
+$itemGroups = $doc.GetElementsByTagName('ItemGroup')
+
+foreach ($pkg in $packages) {
+    $matches = @()
+    foreach ($ig in $itemGroups) {
+        foreach ($child in $ig.ChildNodes) {
+            if ($child.LocalName -eq 'Reference') {
+                $includeAttr = $null
+                if ($child.Attributes -and $child.Attributes['Include']) {
+                    $includeAttr = $child.Attributes['Include'].Value
+                }
+                $hintNode = $child.SelectSingleNode("*[local-name() = 'HintPath']")
+                $hintVal = if ($hintNode) { $hintNode.InnerText } else { '' }
+
+                # Only match if the Include attribute exactly matches a package name
+                $matchedPkg = $null
+                foreach ($pkg in $packages) {
+                    if ($includeAttr -eq $pkg) {
+                        $matchedPkg = $pkg
+                        break
+                    }
+                }
+
+                if ($matchedPkg) {
+                    $newHint = Join-Path -Path $PuckPath -ChildPath "Puck_Data\Managed\$matchedPkg.dll"
+                    if (-not $hintNode) {
+                        $hintNode = $doc.CreateElement('HintPath')
+                        $child.AppendChild($hintNode) | Out-Null
+                    }
+                    $hintNode.InnerText = $newHint
+                    # Optionally update Include attribute to match the package name exactly
+                    if ($child.Attributes -and $child.Attributes['Include']) {
+                        $child.Attributes['Include'].Value = $matchedPkg
+                    }
+                }
+            }
+        }
+    }
+}
+
+# Save changes back to file
+$doc.Save($CSProjFilePath)
+Write-Output "Updated $CSProjFilePath (backup saved to $bakPath)"

--- a/Scripts/SetupProjectReferences.ps1
+++ b/Scripts/SetupProjectReferences.ps1
@@ -1,0 +1,22 @@
+# Script permettant de configurer les références de projet en changeant les chemins d'accès aux DLLs de Puck.
+# Il faut exécuter ce script depuis le répertoire Scripts et ne pas exécuter FixReferences.ps1 directement.
+# Après avoir exécuté ce script, il faut recharger tout les projets dans Visual Studio pour que les modifications soient prises en compte.
+
+$PuckPath = "C:\Program Files (x86)\Steam\steamapps\common\Puck"
+
+# J'utilise Resolve-Path pour obtenir le chemin absolu des fichiers .csproj, ce qui évite les problèmes liés aux chemins relatifs.
+.\FixReferences.ps1 `
+-CSProjFilePath $(Resolve-Path -Path "..\Stats\Stats.csproj") `
+-PuckPath $PuckPath
+
+.\FixReferences.ps1 `
+-CSProjFilePath $(Resolve-Path -Path "..\Sounds\Sounds.csproj") `
+-PuckPath $PuckPath
+
+.\FixReferences.ps1 `
+-CSProjFilePath $(Resolve-Path -Path "..\SoundsPack\SoundsPack.csproj") `
+-PuckPath $PuckPath
+
+.\FixReferences.ps1 `
+-CSProjFilePath $(Resolve-Path -Path "..\Ruleset\Ruleset.csproj") `
+-PuckPath $PuckPath


### PR DESCRIPTION
J'ai créé un script qui permet de changer les paths des DLL (Assemblies et References) de Visual Studio 2022 sans avoir à le faire par GUI.

Il faut changer la variable PuckPath dans le script SetupProjectReferences.ps1 et exécuter le script en étant dans le dossier Scripts.

### 1. Le projet avec les assemblies et references broken
<img width="1324" height="786" alt="image" src="https://github.com/user-attachments/assets/c3f35be2-ea8a-49a4-9298-ffd5ede68a41" />

### 2. On change la variable PuckPath dans le script SetupProjectReferences.ps1
<img width="1035" height="508" alt="image" src="https://github.com/user-attachments/assets/6599faef-8091-49f5-979e-0b48892cbd3a" />

### 3. On exécute le script après avoir changé la variable PuckPath
<img width="1025" height="368" alt="image" src="https://github.com/user-attachments/assets/dca44577-8d88-4467-a0da-8d752fca2efb" />

### 4. Sortie normale du script
<img width="1161" height="661" alt="image" src="https://github.com/user-attachments/assets/ad7e3436-64b9-4929-b06d-6bb2cf6b8931" />

### 5. On recharge tout et on sauvegarde les changements
<img width="1702" height="935" alt="image" src="https://github.com/user-attachments/assets/2a2168ae-1cb9-42c9-b041-6e0f657d5e37" />

### 6. Les assemblies et références sont chargées.
<img width="1227" height="945" alt="image" src="https://github.com/user-attachments/assets/f629fbb6-2190-4d3e-ae06-eed364e8733e" />
