### PR TITLE
Move faceoff for Goalie Interference

### DIFF
--- a/Ruleset/Faceoff.cs
+++ b/Ruleset/Faceoff.cs
@@ -44,8 +44,9 @@ namespace oomtm450PuckMod_Ruleset {
         /// <returns>FaceoffSpot, next faceoff position.</returns>
         private static FaceoffSpot SetNextFaceoffPositionFromLastTouch(PlayerTeam team, bool left, (Vector3 Position, Zone Zone) puckLastState, Rule rule) {
             Zone puckZone = ZoneFunc.GetZone(puckLastState.Position, puckLastState.Zone, Ruleset.PuckRadius);
+
             if (puckZone == Zone.BlueTeam_BehindGoalLine || puckZone == Zone.BlueTeam_Zone) {
-                if (team == PlayerTeam.Blue || rule == Rule.DelayOfGame || rule == Rule.GoalieInt) {
+                if (team == PlayerTeam.Blue || rule == Rule.DelayOfGame) {
                     if (left)
                         return FaceoffSpot.BlueteamDZoneLeft;
                     else
@@ -59,7 +60,7 @@ namespace oomtm450PuckMod_Ruleset {
                 }
             }
             else if (puckZone == Zone.RedTeam_BehindGoalLine || puckZone == Zone.RedTeam_Zone) {
-                if (team == PlayerTeam.Red || rule == Rule.DelayOfGame || rule == Rule.GoalieInt) {
+                if (team == PlayerTeam.Red || rule == Rule.DelayOfGame) {
                     if (left)
                         return FaceoffSpot.RedteamDZoneLeft;
                     else


### PR DESCRIPTION
A goalie interference (both in Europe and the NHL) means the faceoff is moved out. Fixes #248 

From the IIHF Official Rule Book:

> The Referee shall stop the game and the subsequent face-off shall take place at the nearest Neutral Zone Face-off Spot outside the Attacking Zone of the offending Team.

NHL:

> When the attacking team is responsible for the stoppage of play in the attacking zone, the ensuing face-off shall be conducted at the nearest neutral zone face-off spot outside the attacking zone.