### PR TITLE
Pass colliding puck into ResetGoalAndAssistAttribution

### DIFF
--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -607,7 +607,7 @@ namespace oomtm450PuckMod_Ruleset {
                             __instance.Rigidbody.transform.position.y, ServerConfig.Faceoff.PuckIceContactHeight) || _lastPlayerOnPuckSteamId[_lastPlayerOnPuckTeam] == playerSteamId) {
                             _lastPlayerOnPuckTeam = stick.Player.Team;
                             if (!Codebase.PlayerFunc.IsGoalie(stick.Player))
-                                ResetGoalAndAssistAttribution(TeamFunc.GetOtherTeam(_lastPlayerOnPuckTeam));
+                                ResetGoalAndAssistAttribution(TeamFunc.GetOtherTeam(_lastPlayerOnPuckTeam), __instance);
 
                             _lastPlayerOnPuckSteamId[stick.Player.Team] = playerSteamId;
                             _playersOnPuckDateTime.AddOrUpdate(playerSteamId, (stick.Player.Team, now));
@@ -705,7 +705,7 @@ namespace oomtm450PuckMod_Ruleset {
                             __instance.Rigidbody.transform.position.y, ServerConfig.Faceoff.PuckIceContactHeight) || _lastPlayerOnPuckSteamId[_lastPlayerOnPuckTeam] == currentPlayerSteamId) {
                             _lastPlayerOnPuckTeam = stick.Player.Team;
                             if (!Codebase.PlayerFunc.IsGoalie(stick.Player))
-                                ResetGoalAndAssistAttribution(TeamFunc.GetOtherTeam(_lastPlayerOnPuckTeam));
+                                ResetGoalAndAssistAttribution(TeamFunc.GetOtherTeam(_lastPlayerOnPuckTeam), __instance);
 
                             _lastPlayerOnPuckSteamId[stick.Player.Team] = currentPlayerSteamId;
                             _playersOnPuckDateTime.AddOrUpdate(currentPlayerSteamId, (stick.Player.Team, now));
@@ -2362,9 +2362,9 @@ namespace oomtm450PuckMod_Ruleset {
                 return ServerConfig.GInt.RedTeam;
         }
 
-        private static void ResetGoalAndAssistAttribution(PlayerTeam team) {
+        private static void ResetGoalAndAssistAttribution(PlayerTeam team, Puck puck = null) {
             try {
-                NetworkList<NetworkObjectCollision> buffer = GetPuckBuffer() ?? throw new NullReferenceException("Buffer field is null !!!");
+                NetworkList<NetworkObjectCollision> buffer = GetPuckBuffer(puck) ?? throw new NullReferenceException("Buffer field is null !!!");
 
                 List<NetworkObjectCollision> collisionToRemove = new List<NetworkObjectCollision>();
                 foreach (NetworkObjectCollision collision in buffer) {


### PR DESCRIPTION
## Summary

- `Puck_OnCollisionStay_Patch.Postfix` and `Puck_OnCollisionExit_Patch.Postfix` both call `ResetGoalAndAssistAttribution` while `Puck __instance` is already in scope, but the method internally falls back to `PuckManager.Instance.GetPuck()` via `GetPuckBuffer()`.
- When the live puck has just been despawned mid-frame (OOB transition, goal teardown, etc.) `PuckManager.GetPucks(false)` is empty, so `GetPuck()` returns null and the `?? throw new NullReferenceException(""Buffer field is null !!!"")` fires even though the colliding puck is right there in `__instance`.
- This PR threads `__instance` through `ResetGoalAndAssistAttribution(team, puck)` → `GetPuckBuffer(puck)`. `GetPuckBuffer` already accepted an optional `Puck`, so no other call sites change.

Observed crash trace this fixes:
```
[ERROR] [oomtm450_ruleset] Error in ResetGoalAndAssistAttribution.
System.NullReferenceException: Buffer field is null !!!
```

## Test plan

- [ ] Trigger the previous crash window (stick collision against the puck near an OOB / phase transition where the live puck has just been despawned) and confirm no ``Buffer field is null !!!`` errors.
- [ ] Normal play: confirm goal/assist attribution still resets correctly on opposing-team stick touches.
- [ ] Verify other callers of `GetPuckBuffer` (none in current source) are unaffected — the new parameter is optional and defaults to the previous behavior.

## Follow-up (not in this PR)

Consider an early-return guard at the top of the three `Puck_OnCollision*_Patch` postfixes for `__instance.IsReplay?.Value == true` or `!__instance.NetworkObject.IsSpawned`. The current `Phase != GamePhase.Play` check covers the common case but doesn't strictly forbid replay/transient pucks from entering ruleset logic. Happy to put that in a follow-up PR if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)