### PR TITLE
Potential stats fix for players showing up on matches that occur long after they have disconnected

### DIFF
--- a/Stats/Stats.cs
+++ b/Stats/Stats.cs
@@ -536,6 +536,13 @@ namespace oomtm450PuckMod_Stats {
                     NetworkCommunication.SendDataToAll(RESET_ALL, "1", Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
 
                     _sentOutOfDateMessage.Clear();
+
+                    // Remove teams of players that are no longer connected (covers leavers the end of game seems to miss)
+                    foreach (string steamId in new List<string>(_playersTeam.Keys)) {
+                        Player player = PlayerManager.Instance.GetPlayerBySteamId(steamId);
+                        if (player == null || !player)
+                            _playersTeam.Remove(steamId);
+                    }
                 }
                 catch (Exception ex) {
                     Logging.LogError($"Error in {nameof(BaseGameMode_OnGameStateChanged_Patch)} Postfix().\n{ex}", ServerConfig);


### PR DESCRIPTION
Clear _playersTeam dict at pregame and warmup for extra insurance against ghost players in teams. Stats files have extra steamids in the teams key of players that have left earlier (in previous matches). This was reported by Bone, but after reviewing the server logs and stats files the teams grows over until server restart right now. 

I've preserved the logs/stats files on NY in directory `bone_review`

<img width="2080" height="910" alt="teams_ghost_accumulation" src="https://github.com/user-attachments/assets/9cab1548-b4bc-404d-9945-bae0ba1c79a6" />
