### PR TITLE
Hotfixes to Ruleset, Stats and Sounds

### DIFF
--- a/Ruleset/Configs/ServerConfig.cs
+++ b/Ruleset/Configs/ServerConfig.cs
@@ -28,6 +28,9 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// </summary>
         [JsonIgnore]
         private static readonly string CONFIG_PATH = Path.Combine(CONFIG_FOLDER_PATH, Constants.MOD_NAME + "_serverconfig.json");
+
+        [JsonIgnore]
+        internal const float DEFAULT_PLAYER_HEIGHT = 0.0338f; // TODO : Check in new Puck build.
         #endregion
 
         #region Properties
@@ -100,7 +103,7 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// <summary>
         /// Float, default standing player height.
         /// </summary>
-        public float DefaultPlayerHeight { get; set; } = 0.0338f; // TODO : Check in new Puck build.
+        public float DefaultPlayerHeight { get; set; } = DEFAULT_PLAYER_HEIGHT;
 
         /// <summary>
         /// Bool, true the mod has to log all phase changes and stoppages.
@@ -811,7 +814,7 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// <summary>
         /// Float, base height before hitting the puck with a stick is considered high stick.
         /// </summary>
-        public float MaxHeight { get; set; } = Codebase.Constants.CROSSBAR_HEIGHT + 0.05f;
+        public float MaxHeight { get; set; } = Codebase.Constants.CROSSBAR_HEIGHT + 0.05f + ServerConfig.DEFAULT_PLAYER_HEIGHT;
 
         /// <summary>
         /// Int, number of milliseconds after a high stick to call high stick if no one touches the puck.

--- a/Ruleset/Configs/ServerConfig.cs
+++ b/Ruleset/Configs/ServerConfig.cs
@@ -83,7 +83,7 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// <summary>
         /// Int, number of milliseconds for a puck to not be considered tipped by a player's stick.
         /// </summary>
-        public int MaxTippedMilliseconds { get; set; } = 32;
+        public int MaxTippedMilliseconds { get; set; } = 33;
 
         /// <summary>
         /// Int, number of milliseconds for a possession to be considered with challenge.
@@ -361,9 +361,9 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// </summary>
         public float DelayOfGameZDelta { get; set; } = 0.0125f;
         /// <summary>
-        /// Int, delay of game can be called if someone didn't touch the puck this number of milliseconds before leaving the stick.
+        /// Int, delay of game can be called if someone didn't touch the puck this number of milliseconds on the other team.
         /// </summary>
-        public int DelayOfGameMillisecondsThreshold { get; set; } = 0; // TODO : Check to remove if 0 is fine.
+        public int DelayOfGameMillisecondsThreshold { get; set; } = 25;
 
         /// <summary>
         /// Bool, true if faceoff violation penalty is enabled.

--- a/Ruleset/Configs/ServerConfig.cs
+++ b/Ruleset/Configs/ServerConfig.cs
@@ -80,7 +80,7 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// <summary>
         /// Int, number of milliseconds for a puck to not be considered tipped by a player's stick.
         /// </summary>
-        public int MaxTippedMilliseconds { get; set; } = 34;
+        public int MaxTippedMilliseconds { get; set; } = 32;
 
         /// <summary>
         /// Int, number of milliseconds for a possession to be considered with challenge.

--- a/Ruleset/Configs/ServerConfig.cs
+++ b/Ruleset/Configs/ServerConfig.cs
@@ -360,7 +360,7 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// <summary>
         /// Int, delay of game can be called if someone didn't touch the puck this number of milliseconds before leaving the stick.
         /// </summary>
-        public int DelayOfGameMillisecondsThreshold { get; set; } = 10;
+        public int DelayOfGameMillisecondsThreshold { get; set; } = 0; // TODO : Check to remove if 0 is fine.
 
         /// <summary>
         /// Bool, true if faceoff violation penalty is enabled.

--- a/Ruleset/Configs/ServerConfig.cs
+++ b/Ruleset/Configs/ServerConfig.cs
@@ -317,7 +317,7 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// <summary>
         /// Int, time in the box for a player interference penalty in milliseconds.
         /// </summary>
-        public int InterferenceTime { get; set; } = 45000;
+        public int InterferenceTime { get; set; } = PenaltyModule.LONG_PENALTY_TIME_MS;
         /// <summary>
         /// Int, interference can be called after this number of milliseconds after touching the puck.
         /// </summary>
@@ -338,7 +338,7 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// <summary>
         /// Int, time in the box for a goalie interference penalty in milliseconds.
         /// </summary>
-        public int GoalieInterferenceTime { get; set; } = 45000;
+        public int GoalieInterferenceTime { get; set; } = PenaltyModule.LONG_PENALTY_TIME_MS;
 
         /// <summary>
         /// Int, time for a late slip/fall to be considered as interference against the opposing player.
@@ -352,7 +352,7 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// <summary>
         /// Int, time in the box for a delay of game penalty in milliseconds.
         /// </summary>
-        public int DelayOfGameTime { get; set; } = 45000;
+        public int DelayOfGameTime { get; set; } = PenaltyModule.LONG_PENALTY_TIME_MS;
         /// <summary>
         /// Float, delta of the puck Z direction to use with the delay of game.
         /// </summary>
@@ -369,7 +369,7 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// <summary>
         /// Int, time in the box for a faceoff violation penalty in milliseconds.
         /// </summary>
-        public int FaceoffViolationTime { get; set; } = 30000;
+        public int FaceoffViolationTime { get; set; } = PenaltyModule.SHORT_PENALTY_TIME_MS;
 
         /// <summary>
         /// Bool, true if embellishment penalty is enabled.
@@ -378,7 +378,7 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// <summary>
         /// Int, time in the box for an embellishment penalty in milliseconds.
         /// </summary>
-        public int EmbellishmentTime { get; set; } = 30000;
+        public int EmbellishmentTime { get; set; } = PenaltyModule.SHORT_PENALTY_TIME_MS;
         /// <summary>
         /// Int, embellishment can be called after this number of milliseconds after the player gets up.
         /// </summary>
@@ -395,7 +395,7 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// <summary>
         /// Int, time in the box for a roughing penalty in milliseconds.
         /// </summary>
-        public int RoughingTime { get; set; } = 30000;
+        public int RoughingTime { get; set; } = PenaltyModule.SHORT_PENALTY_TIME_MS;
         /// <summary>
         /// Int, roughing can be called after this number of milliseconds after the player gets up.
         /// </summary>
@@ -412,7 +412,7 @@ namespace oomtm450PuckMod_Ruleset.Configs {
         /// <summary>
         /// Int, time in the box for a charging penalty in milliseconds.
         /// </summary>
-        public int ChargingTime { get; set; } = 45000;
+        public int ChargingTime { get; set; } = PenaltyModule.LONG_PENALTY_TIME_MS;
         #endregion
 
         #region Constructors

--- a/Ruleset/Penalty.cs
+++ b/Ruleset/Penalty.cs
@@ -354,6 +354,9 @@ namespace oomtm450PuckMod_Ruleset {
             PenalizedPlayersCountRedTeam = 0;
             PenalizedPlayersInBoxCountRedTeam = 0;
 
+            PenaltyToBeCalled[PlayerTeam.Blue] = false;
+            PenaltyToBeCalled[PlayerTeam.Red] = false;
+
             foreach (PlayerTeam key in new List<PlayerTeam>(PositionIsPenalized.Keys))
                 PositionIsPenalized[key] = new LockDictionary<string, bool>(POSITION_IS_PENALIZED_DEFAULT);
 

--- a/Ruleset/Penalty.cs
+++ b/Ruleset/Penalty.cs
@@ -457,7 +457,10 @@ namespace oomtm450PuckMod_Ruleset {
             if (Codebase.PlayerFunc.IsGoalie(penalizedPlayer) || penalizedPlayer.PlayerPosition.Name == Codebase.PlayerFunc.GOALIE_POSITION) {
                 List<Player> possiblePlayersToPenalize = new List<Player>();
                 foreach (Player teamPlayer in teamPlayers) {
-                    if (!PenalizedPlayers.TryGetValue(penalizedPlayer.SteamId.Value.ToString(), out LockList<Penalty> __penaltyList))
+                    if (!Codebase.PlayerFunc.IsPlayerPlaying(teamPlayer))
+                        continue;
+
+                    if (!PenalizedPlayers.TryGetValue(teamPlayer.SteamId.Value.ToString(), out LockList<Penalty> __penaltyList))
                         continue;
 
                     if (__penaltyList.Count != 0)
@@ -472,7 +475,7 @@ namespace oomtm450PuckMod_Ruleset {
                 penalizedPlayer = possiblePlayersToPenalize.OrderBy(x => x.Goals.Value + x.Assists.Value).First();
                 penalizedPlayerSteamId = penalizedPlayer.SteamId.Value.ToString();
 
-                if (!PenalizedPlayers.TryGetValue(penalizedPlayer.SteamId.Value.ToString(), out LockList<Penalty> _penaltyList)) {
+                if (!PenalizedPlayers.TryGetValue(penalizedPlayerSteamId, out LockList<Penalty> _penaltyList)) {
                     _penaltyList = new LockList<Penalty>();
                     PenalizedPlayers.Add(penalizedPlayerSteamId, _penaltyList);
                 }

--- a/Ruleset/Penalty.cs
+++ b/Ruleset/Penalty.cs
@@ -460,11 +460,10 @@ namespace oomtm450PuckMod_Ruleset {
                     if (!Codebase.PlayerFunc.IsPlayerPlaying(teamPlayer))
                         continue;
 
-                    if (!PenalizedPlayers.TryGetValue(teamPlayer.SteamId.Value.ToString(), out LockList<Penalty> __penaltyList))
-                        continue;
-
-                    if (__penaltyList.Count != 0)
-                        continue;
+                    if (PenalizedPlayers.TryGetValue(teamPlayer.SteamId.Value.ToString(), out LockList<Penalty> __penaltyList)) {
+                        if (__penaltyList.Count != 0)
+                            continue;
+                    }
 
                     possiblePlayersToPenalize.Add(teamPlayer);
                 }

--- a/Ruleset/Penalty.cs
+++ b/Ruleset/Penalty.cs
@@ -12,6 +12,9 @@ namespace oomtm450PuckMod_Ruleset {
         internal const string REMOVE_ALL_PENALTIES_REFMODE_DATANAME = Constants.MOD_NAME + "refremoveallpen";
         internal const string REMOVE_PENALTY_DATANAME = Constants.MOD_NAME + "removepen";
 
+        internal const int LONG_PENALTY_TIME_MS = 45000;
+        internal const int SHORT_PENALTY_TIME_MS = 30000;
+
         private static readonly Vector3 BLUE_PENALTY_BOX_POSITION_DEFAULT = new Vector3(26f, 0.9f, 1.5f); // TODO : Config.
         private static Vector3 BLUE_PENALTY_BOX_POSITION { get; set; }
 
@@ -706,7 +709,7 @@ namespace oomtm450PuckMod_Ruleset {
             return true;
         }
 
-        internal static string FakePlayerPositionForFaceoffByAvailability(string position, PlayerTeam team, List<string> claimedPositions) {
+        internal static string FakePlayerPositionForFaceoffByAvailability(string position, PlayerTeam team, List<(string Position, bool IsPenalized)> claimedPositions) {
             if (team == PlayerTeam.Blue && PenalizedPlayersCountBlueTeam == 0)
                 return position;
 
@@ -715,26 +718,26 @@ namespace oomtm450PuckMod_Ruleset {
 
             switch (position) {
                 case Codebase.PlayerFunc.RIGHT_WINGER_POSITION:
-                    if (!claimedPositions.Contains(Codebase.PlayerFunc.LEFT_WINGER_POSITION))
+                    if (!claimedPositions.Any(x => !x.IsPenalized && x.Position == Codebase.PlayerFunc.LEFT_WINGER_POSITION))
                         return Codebase.PlayerFunc.LEFT_WINGER_POSITION;
                     break;
 
                 case Codebase.PlayerFunc.LEFT_DEFENDER_POSITION:
-                    if (!claimedPositions.Contains(Codebase.PlayerFunc.LEFT_WINGER_POSITION) && !claimedPositions.Contains(Codebase.PlayerFunc.RIGHT_WINGER_POSITION))
+                    if (!claimedPositions.Any(x => !x.IsPenalized && x.Position == Codebase.PlayerFunc.LEFT_WINGER_POSITION) && !claimedPositions.Any(x => !x.IsPenalized && x.Position == Codebase.PlayerFunc.RIGHT_WINGER_POSITION))
                         return Codebase.PlayerFunc.LEFT_WINGER_POSITION;
 
-                    if (!claimedPositions.Contains(Codebase.PlayerFunc.RIGHT_WINGER_POSITION))
+                    if (!claimedPositions.Any(x => !x.IsPenalized && x.Position == Codebase.PlayerFunc.RIGHT_WINGER_POSITION))
                         return Codebase.PlayerFunc.RIGHT_WINGER_POSITION;
                     break;
 
                 case Codebase.PlayerFunc.RIGHT_DEFENDER_POSITION:
-                    if (!claimedPositions.Contains(Codebase.PlayerFunc.LEFT_WINGER_POSITION) && !claimedPositions.Contains(Codebase.PlayerFunc.RIGHT_WINGER_POSITION) && !claimedPositions.Contains(Codebase.PlayerFunc.LEFT_DEFENDER_POSITION))
+                    if (!claimedPositions.Any(x => !x.IsPenalized && x.Position == Codebase.PlayerFunc.LEFT_WINGER_POSITION) && !claimedPositions.Any(x => !x.IsPenalized && x.Position == Codebase.PlayerFunc.RIGHT_WINGER_POSITION) && !claimedPositions.Any(x => !x.IsPenalized && x.Position == Codebase.PlayerFunc.LEFT_DEFENDER_POSITION))
                         return Codebase.PlayerFunc.LEFT_WINGER_POSITION;
 
-                    if (!claimedPositions.Contains(Codebase.PlayerFunc.RIGHT_WINGER_POSITION) && !claimedPositions.Contains(Codebase.PlayerFunc.LEFT_DEFENDER_POSITION))
+                    if (!claimedPositions.Any(x => !x.IsPenalized && x.Position == Codebase.PlayerFunc.RIGHT_WINGER_POSITION) && !claimedPositions.Any(x => !x.IsPenalized && x.Position == Codebase.PlayerFunc.LEFT_DEFENDER_POSITION))
                         return Codebase.PlayerFunc.RIGHT_WINGER_POSITION;
 
-                    if (!claimedPositions.Contains(Codebase.PlayerFunc.LEFT_DEFENDER_POSITION))
+                    if (!claimedPositions.Any(x => !x.IsPenalized && x.Position == Codebase.PlayerFunc.LEFT_DEFENDER_POSITION))
                         return Codebase.PlayerFunc.LEFT_DEFENDER_POSITION;
                     break;
             }
@@ -742,48 +745,41 @@ namespace oomtm450PuckMod_Ruleset {
             return position;
         }
 
-        internal static string GetPlayerPositionForFaceoff(string position, PlayerTeam team, FaceoffSpot faceoffSpot, List<string> claimedPositions) {
+        internal static string GetPlayerPositionForFaceoff(string position, PlayerTeam team, FaceoffSpot faceoffSpot, List<(string Position, bool IsPenalized)> claimedPositions) {
             position = FakePlayerPositionForFaceoffByAvailability(position, team, claimedPositions);
+
+            bool centerPositionIsOpen = PositionIsPenalized[team][Codebase.PlayerFunc.CENTER_POSITION] && !claimedPositions.Any(x => !x.IsPenalized && x.Position == Codebase.PlayerFunc.CENTER_POSITION);
+            bool leftDefenderPositionIsOpen = PositionIsPenalized[team][Codebase.PlayerFunc.LEFT_DEFENDER_POSITION] && !claimedPositions.Any(x => !x.IsPenalized && x.Position == Codebase.PlayerFunc.LEFT_DEFENDER_POSITION);
 
             switch (position) {
                 case Codebase.PlayerFunc.LEFT_WINGER_POSITION:
-                    if (team == PlayerTeam.Blue) {
-                        if (PositionIsPenalized[team][Codebase.PlayerFunc.CENTER_POSITION])
-                            return Codebase.PlayerFunc.CENTER_POSITION;
-                        else if (PositionIsPenalized[team][Codebase.PlayerFunc.LEFT_DEFENDER_POSITION])
-                            return Codebase.PlayerFunc.LEFT_DEFENDER_POSITION;
-                    }
-                    else {
-                        if (PositionIsPenalized[team][Codebase.PlayerFunc.CENTER_POSITION])
-                            return Codebase.PlayerFunc.CENTER_POSITION;
-                        else if (PositionIsPenalized[team][Codebase.PlayerFunc.LEFT_DEFENDER_POSITION])
-                            return Codebase.PlayerFunc.LEFT_DEFENDER_POSITION;
-                    }
+                    if (centerPositionIsOpen)
+                        return Codebase.PlayerFunc.CENTER_POSITION;
+                    if (leftDefenderPositionIsOpen)
+                        return Codebase.PlayerFunc.LEFT_DEFENDER_POSITION;
                     break;
 
                 case Codebase.PlayerFunc.RIGHT_WINGER_POSITION:
+                    bool leftWingerPositionIsOpen = PositionIsPenalized[team][Codebase.PlayerFunc.LEFT_WINGER_POSITION] && !claimedPositions.Any(x => !x.IsPenalized && x.Position == Codebase.PlayerFunc.LEFT_WINGER_POSITION);
+
+                    if (centerPositionIsOpen && leftWingerPositionIsOpen)
+                        return Codebase.PlayerFunc.CENTER_POSITION;
+
                     if (team == PlayerTeam.Blue) {
-                        if (PositionIsPenalized[team][Codebase.PlayerFunc.CENTER_POSITION] && PositionIsPenalized[team][Codebase.PlayerFunc.LEFT_WINGER_POSITION])
-                            return Codebase.PlayerFunc.CENTER_POSITION;
-                        else if (PositionIsPenalized[team][Codebase.PlayerFunc.CENTER_POSITION] && (faceoffSpot == FaceoffSpot.BlueteamBLLeft || faceoffSpot == FaceoffSpot.RedteamBLLeft || faceoffSpot == FaceoffSpot.BlueteamDZoneLeft || faceoffSpot == FaceoffSpot.RedteamDZoneLeft || faceoffSpot == FaceoffSpot.Center)) {
+                        if (centerPositionIsOpen && (faceoffSpot == FaceoffSpot.BlueteamBLLeft || faceoffSpot == FaceoffSpot.RedteamBLLeft || faceoffSpot == FaceoffSpot.BlueteamDZoneLeft || faceoffSpot == FaceoffSpot.RedteamDZoneLeft || faceoffSpot == FaceoffSpot.Center))
                             return Codebase.PlayerFunc.LEFT_WINGER_POSITION;
-                        }
-                        else if (PositionIsPenalized[team][Codebase.PlayerFunc.RIGHT_DEFENDER_POSITION])
-                            return Codebase.PlayerFunc.RIGHT_DEFENDER_POSITION;
-                        else if (PositionIsPenalized[team][Codebase.PlayerFunc.CENTER_POSITION] && PositionIsPenalized[team][Codebase.PlayerFunc.LEFT_DEFENDER_POSITION])
-                            return Codebase.PlayerFunc.LEFT_DEFENDER_POSITION;
                     }
                     else {
-                        if (PositionIsPenalized[team][Codebase.PlayerFunc.CENTER_POSITION] && PositionIsPenalized[team][Codebase.PlayerFunc.LEFT_WINGER_POSITION])
-                            return Codebase.PlayerFunc.CENTER_POSITION;
-                        else if (PositionIsPenalized[team][Codebase.PlayerFunc.CENTER_POSITION] && (faceoffSpot == FaceoffSpot.BlueteamBLRight || faceoffSpot == FaceoffSpot.RedteamBLRight || faceoffSpot == FaceoffSpot.BlueteamDZoneRight || faceoffSpot == FaceoffSpot.RedteamDZoneRight || faceoffSpot == FaceoffSpot.Center)) {
+                        if (centerPositionIsOpen && (faceoffSpot == FaceoffSpot.BlueteamBLRight || faceoffSpot == FaceoffSpot.RedteamBLRight || faceoffSpot == FaceoffSpot.BlueteamDZoneRight || faceoffSpot == FaceoffSpot.RedteamDZoneRight || faceoffSpot == FaceoffSpot.Center))
                             return Codebase.PlayerFunc.LEFT_WINGER_POSITION;
-                        }
-                        else if (PositionIsPenalized[team][Codebase.PlayerFunc.RIGHT_DEFENDER_POSITION])
-                            return Codebase.PlayerFunc.RIGHT_DEFENDER_POSITION;
-                        else if (PositionIsPenalized[team][Codebase.PlayerFunc.CENTER_POSITION] && PositionIsPenalized[team][Codebase.PlayerFunc.LEFT_DEFENDER_POSITION])
-                            return Codebase.PlayerFunc.LEFT_DEFENDER_POSITION;
                     }
+
+                    bool rightDefenderPositionIsOpen = PositionIsPenalized[team][Codebase.PlayerFunc.RIGHT_DEFENDER_POSITION] && !claimedPositions.Any(x => !x.IsPenalized && x.Position == Codebase.PlayerFunc.RIGHT_DEFENDER_POSITION);
+
+                    if (rightDefenderPositionIsOpen)
+                        return Codebase.PlayerFunc.RIGHT_DEFENDER_POSITION;
+                    if (centerPositionIsOpen && leftDefenderPositionIsOpen)
+                        return Codebase.PlayerFunc.LEFT_DEFENDER_POSITION;
                     break;
             }
 
@@ -815,7 +811,7 @@ namespace oomtm450PuckMod_Ruleset {
                     return Ruleset.ServerConfig.Penalty.ChargingTime;
             }
 
-            return 45000;
+            return PenaltyModule.LONG_PENALTY_TIME_MS;
         }
         #endregion
     }

--- a/Ruleset/Penalty.cs
+++ b/Ruleset/Penalty.cs
@@ -456,7 +456,10 @@ namespace oomtm450PuckMod_Ruleset {
                 if (_playerToUnpenalize == null || !_playerToUnpenalize)
                     return false;
 
-                RemoveOnePenalty(_playerToUnpenalize.Team);
+                if (_penalties.Value.First().Timer.MillisecondsLeft > GetPenaltyTypeTime(penaltyType))
+                    return false;
+
+                RemoveOnePenalty(_playerToUnpenalize.Team, true);
             }
 
             // If goalie has a penalty, take another player.

--- a/Ruleset/Penalty.cs
+++ b/Ruleset/Penalty.cs
@@ -436,12 +436,18 @@ namespace oomtm450PuckMod_Ruleset {
                 if (!unpenalizeOnePlayer)
                     return false;
 
-                KeyValuePair<string, LockList<Penalty>> _penalties = PenalizedPlayers.Where(x => x.Value.Count == 1 && x.Value.First().Team == penalizedPlayer.Team).OrderBy(x => x.Value.Min(y => y.Timer.MillisecondsLeft)).FirstOrDefault();
-                if (_penalties.Equals(default(KeyValuePair<string, LockList<Penalty>>)))
+                var _penaltiesLINQ = PenalizedPlayers.Where(x => x.Value.Count == 1 && x.Value.First().Team == penalizedPlayer.Team).OrderBy(x => x.Value.Min(y => y.Timer.MillisecondsLeft));
+                if (!_penaltiesLINQ.Any())
                     return false;
 
-                Player _playerToUnpenalize = teamPlayers.FirstOrDefault(x => x.SteamId.Value.ToString() == _penalties.Key);
-                if (_playerToUnpenalize == null || _playerToUnpenalize.Equals(default(Player)))
+                KeyValuePair<string, LockList<Penalty>> _penalties = _penaltiesLINQ.First();
+
+                var _playerToUnpenalizeLINQ = teamPlayers.Where(x => x.SteamId.Value.ToString() == _penalties.Key);
+                if (!_playerToUnpenalizeLINQ.Any())
+                    return false;
+
+                Player _playerToUnpenalize = _playerToUnpenalizeLINQ.First();
+                if (_playerToUnpenalize == null || !_playerToUnpenalize)
                     return false;
 
                 RemoveOnePenalty(_playerToUnpenalize.Team);

--- a/Ruleset/Penalty.cs
+++ b/Ruleset/Penalty.cs
@@ -690,8 +690,7 @@ namespace oomtm450PuckMod_Ruleset {
                         return false;
                 }
             }
-
-            if (penalizedPlayerTeam == PlayerTeam.Red) {
+            else if (penalizedPlayerTeam == PlayerTeam.Red) {
                 if (removePendingPenalty) {
                     if (PenalizedPlayersCountRedTeam == 0)
                         return false;

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -1613,8 +1613,11 @@ namespace oomtm450PuckMod_Ruleset {
                             if (!playerTouched)
                                 lastTouchDateTime = (_lastPlayerOnPuckTeam, DateTime.MinValue);
 
-                            string lastPlayerOnPuckOtherTeamSteamId = _lastPlayerOnPuckSteamId[TeamFunc.GetOtherTeam(_lastPlayerOnPuckTeam)];
+                            PlayerTeam lastPlayerOnPuckOtherTeam = TeamFunc.GetOtherTeam(_lastPlayerOnPuckTeam);
+                            string lastPlayerOnPuckOtherTeamSteamId = _lastPlayerOnPuckSteamId[lastPlayerOnPuckOtherTeam];
                             bool playerTouchedOtherTeam = _playersOnPuckDateTime.TryGetValue(lastPlayerOnPuckOtherTeamSteamId, out var lastTouchOtherTeamDateTime);
+                            if (!playerTouchedOtherTeam)
+                                lastTouchDateTime = (lastPlayerOnPuckOtherTeam, DateTime.MinValue);
 
                             bool playerWasLastInPossession = Codebase.PlayerFunc.GetPlayerSteamIdInPossession(ServerConfig.MinPossessionMilliseconds, ServerConfig.MaxPossessionMilliseconds, _playersCurrentPuckTouch, _lastTimeOnCollisionStayOrExitWasCalled, false) == lastPlayerOnPuckSteamId;
 

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -1605,17 +1605,36 @@ namespace oomtm450PuckMod_Ruleset {
                         else {
                             string lastPlayerOnPuckSteamId = _lastPlayerOnPuckSteamId[_lastPlayerOnPuckTeam];
                             bool playerTouched = _playersOnPuckDateTime.TryGetValue(lastPlayerOnPuckSteamId, out var lastTouchDateTime);
+
+                            string lastPlayerOnPuckOtherTeamSteamId = _lastPlayerOnPuckSteamId[TeamFunc.GetOtherTeam(_lastPlayerOnPuckTeam)];
+                            bool playerTouchedOtherTeam = _playersOnPuckDateTime.TryGetValue(lastPlayerOnPuckOtherTeamSteamId, out var lastTouchOtherTeamDateTime);
+
                             bool playerWasLastInPossession = Codebase.PlayerFunc.GetPlayerSteamIdInPossession(ServerConfig.MinPossessionMilliseconds, ServerConfig.MaxPossessionMilliseconds, _playersCurrentPuckTouch, _lastTimeOnCollisionStayOrExitWasCalled, false) == lastPlayerOnPuckSteamId;
 
                             Logging.Log("playerTouched : " + playerTouched, ServerConfig, true); // TODO
-                            Logging.Log("playerWasLastInPossession : " + playerWasLastInPossession, ServerConfig, true); // TODO
-                            Logging.Log("_puckDeflectedDateTimeSinceLastTouch : " + _puckDeflectedDateTimeSinceLastTouch.ToString("HH:mm:ss.fffffff"), ServerConfig, true); // TODO
-                            Logging.Log("lastTouchDateTime.LastTouchDateTime : " + lastTouchDateTime.LastTouchDateTime.ToString("HH:mm:ss.fffffff"), ServerConfig, true); // TODO
-                            Logging.Log($"_puckDeflectedDateTimeSinceLastTouch > lastTouchDateTime.LastTouchDateTime.AddMilliseconds({ServerConfig.Penalty.DelayOfGameMillisecondsThreshold}) : " + (_puckDeflectedDateTimeSinceLastTouch > lastTouchDateTime.LastTouchDateTime.AddMilliseconds(ServerConfig.Penalty.DelayOfGameMillisecondsThreshold)), ServerConfig, true); // TODO
+                            Logging.Log("playerTouchedOtherTeam : " + playerTouchedOtherTeam, ServerConfig, true); // TODO
 
-                            playerTouched = playerTouched || playerWasLastInPossession;
+                            Logging.Log("playerWasLastInPossession : " + playerWasLastInPossession, ServerConfig, true); // TODO
+
+                            Logging.Log("_puckDeflectedDateTimeSinceLastTouch : " + _puckDeflectedDateTimeSinceLastTouch.ToString("HH:mm:ss.fffffff"), ServerConfig, true); // TODO
+
+                            Logging.Log("lastTouchDateTime.LastTouchDateTime : " + lastTouchDateTime.LastTouchDateTime.ToString("HH:mm:ss.fffffff"), ServerConfig, true); // TODO
+                            Logging.Log("lastTouchOtherTeamDateTime.LastTouchDateTime : " + lastTouchOtherTeamDateTime.LastTouchDateTime.ToString("HH:mm:ss.fffffff"), ServerConfig, true); // TODO
+
+                            Logging.Log($"_puckDeflectedDateTimeSinceLastTouch > lastTouchDateTime.LastTouchDateTime : " + (_puckDeflectedDateTimeSinceLastTouch > lastTouchDateTime.LastTouchDateTime), ServerConfig, true); // TODO
+
+                            bool otherTeamTouchedTooClose = false;
+                            if (playerTouchedOtherTeam && (lastTouchDateTime.LastTouchDateTime - lastTouchOtherTeamDateTime.LastTouchDateTime).TotalMilliseconds < ServerConfig.Penalty.DelayOfGameMillisecondsThreshold)
+                                otherTeamTouchedTooClose = true;
+
+                            Logging.Log($"(lastTouchDateTime.LastTouchDateTime - lastTouchOtherTeamDateTime.LastTouchDateTime).TotalMilliseconds : {(lastTouchDateTime.LastTouchDateTime - lastTouchOtherTeamDateTime.LastTouchDateTime).TotalMilliseconds}", ServerConfig, true); // TODO
+                            Logging.Log($"ServerConfig.Penalty.DelayOfGameMillisecondsThreshold : {ServerConfig.Penalty.DelayOfGameMillisecondsThreshold}", ServerConfig, true); // TODO
+                            Logging.Log("otherTeamTouchedTooClose : " + otherTeamTouchedTooClose, ServerConfig, true); // TODO
+
+                            playerTouched = (playerTouched || playerWasLastInPossession);
                             if (!playerTouched ||
-                                (playerTouched && _puckDeflectedDateTimeSinceLastTouch > lastTouchDateTime.LastTouchDateTime.AddMilliseconds(ServerConfig.Penalty.DelayOfGameMillisecondsThreshold)) ||
+                                otherTeamTouchedTooClose ||
+                                (playerTouched && _puckDeflectedDateTimeSinceLastTouch > lastTouchDateTime.LastTouchDateTime) ||
                                 (_lastPlayerOnPuckTeam == PlayerTeam.Blue && _puckLastStateBeforeCall[Rule.DelayOfGame].Zone != Codebase.Zone.BlueTeam_BehindGoalLine && _puckLastStateBeforeCall[Rule.DelayOfGame].Zone != Codebase.Zone.BlueTeam_Zone) || (_lastPlayerOnPuckTeam == PlayerTeam.Red && _puckLastStateBeforeCall[Rule.DelayOfGame].Zone != Codebase.Zone.RedTeam_BehindGoalLine && _puckLastStateBeforeCall[Rule.DelayOfGame].Zone != Codebase.Zone.RedTeam_Zone)) {
                                 CallDelayOfGameStoppage(_lastPlayerOnPuckTeam);
                             }

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -635,7 +635,7 @@ namespace oomtm450PuckMod_Ruleset {
                     if (!_noHighStickFrames.TryGetValue(playerSteamId, out int _))
                         _noHighStickFrames.Add(playerSteamId, int.MaxValue);
 
-                    if (__instance && __instance.Rigidbody.transform.position.y <= ServerConfig.HighStick.MaxHeight + _arenaOffsetY + stick.Player.PlayerBody.Rigidbody.transform.position.y)
+                    if (__instance && __instance.Rigidbody.transform.position.y <= ServerConfig.HighStick.MaxHeight + _arenaOffsetY)
                         _noHighStickFrames[playerSteamId] = 0;
 
                     var puckLastStateBeforeCallOffside = _puckLastStateBeforeCall[Rule.Offside];
@@ -777,7 +777,7 @@ namespace oomtm450PuckMod_Ruleset {
                     if (IsHighStickEnabled(stick.Player.Team) && __instance &&
                         !Codebase.PlayerFunc.IsGoalie(stick.Player) &&
                         !playerHasPossession &&
-                        __instance.Rigidbody.transform.position.y > ServerConfig.HighStick.MaxHeight + _arenaOffsetY + (stick.Player.PlayerBody.Rigidbody.transform.position.y < ServerConfig.DefaultPlayerHeight ? ServerConfig.DefaultPlayerHeight : stick.Player.PlayerBody.Rigidbody.transform.position.y)) {
+                        __instance.Rigidbody.transform.position.y > ServerConfig.HighStick.MaxHeight + _arenaOffsetY) {
                         if (!_noHighStickFrames.TryGetValue(currentPlayerSteamId, out int noHighStickFrames)) {
                             noHighStickFrames = int.MaxValue;
                             _noHighStickFrames.Add(currentPlayerSteamId, noHighStickFrames);

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -624,6 +624,9 @@ namespace oomtm450PuckMod_Ruleset {
 
                     string playerSteamId = stick.Player.SteamId.Value.ToString();
 
+                    if (string.IsNullOrEmpty(playerSteamId))
+                        return;
+
                     bool playerHasPossession = Codebase.PlayerFunc.GetPlayerSteamIdInPossession(ServerConfig.MinPossessionMilliseconds, ServerConfig.MaxPossessionMilliseconds, _playersCurrentPuckTouch, _lastTimeOnCollisionStayOrExitWasCalled, false) == playerSteamId;
 
                     if (!_lastTimeOnCollisionStayOrExitWasCalled.TryGetValue(playerSteamId, out Stopwatch lastTimeCollisionWatch)) {
@@ -729,6 +732,8 @@ namespace oomtm450PuckMod_Ruleset {
                     _puckZoneLastTouched = _puckZone;
 
                     string currentPlayerSteamId = stick.Player.SteamId.Value.ToString();
+                    if (string.IsNullOrEmpty(currentPlayerSteamId))
+                        return;
 
                     bool playerHasPossession = Codebase.PlayerFunc.GetPlayerSteamIdInPossession(ServerConfig.MinPossessionMilliseconds, ServerConfig.MaxPossessionMilliseconds, _playersCurrentPuckTouch, _lastTimeOnCollisionStayOrExitWasCalled, false) == currentPlayerSteamId;
 

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -4273,7 +4273,7 @@ namespace oomtm450PuckMod_Ruleset {
             _paused = false;
         }
 
-        internal static List<string> GetClaimedPositions(PlayerTeam team) {
+        internal static List<(string Position, bool IsPenalized)> GetClaimedPositions(PlayerTeam team) {
             List<PlayerPosition> positions = new List<PlayerPosition>();
             Dictionary<PlayerPosition, VisualElement> playerPositions = SystemFunc.GetPrivateField<Dictionary<PlayerPosition, VisualElement>>(typeof(UIPositionSelect), UIManager.Instance.PositionSelect, "playerPositionVisualElementMap");
 
@@ -4282,10 +4282,15 @@ namespace oomtm450PuckMod_Ruleset {
                     positions.Add(ppos);
             }
 
-            List<string> claimedPositions = new List<string>();
+            List<(string Position, bool IsPenalized)> claimedPositions = new List<(string, bool)>();
             foreach (PlayerPosition playerPosition in positions) {
-                if (playerPosition.IsClaimed)
-                    claimedPositions.Add(playerPosition.Name);
+                if (playerPosition.IsClaimed) {
+                    string playerSteamId = playerPosition.ClaimedByPlayer.SteamId.Value.ToString();
+                    if (PenaltyModule.PenalizedPlayers.Any(x => x.Key == playerSteamId) && PenaltyModule.PenalizedPlayers[playerSteamId].Count != 0)
+                        claimedPositions.Add((playerPosition.Name, true));
+                    else
+                        claimedPositions.Add((playerPosition.Name, false));
+                }
             }
 
             return claimedPositions;

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -1944,6 +1944,7 @@ namespace oomtm450PuckMod_Ruleset {
         [HarmonyPatch(typeof(BaseGameMode<BaseGameModeConfig>), "ScoreGoal")]
         public class BaseGameMode_ScoreGoal_Patch {
             [HarmonyPrefix]
+            [HarmonyPriority(Priority.First)]
             public static bool Prefix(PlayerTeam byTeam, ref Player goalPlayer, ref Player assistPlayer, ref Player secondAssistPlayer, Puck puck) {
                 try {
                     // If this is not the server or logic is paused, do not use the patch.

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -568,14 +568,10 @@ namespace oomtm450PuckMod_Ruleset {
                     if (IsHighStick(stick.Player.Team)) {
                         Puck puck = PuckManager.Instance.GetPuck();
                         if (puck && puck.Rigidbody.transform.position.y < PuckRadius + _arenaOffsetY) {
-                            NextFaceoffSpot = Faceoff.GetNextFaceoffPosition(stick.Player.Team, Rule.HighStick, _puckLastStateBeforeCall[Rule.HighStick]);
-
                             _isHighStickActiveTimers.TryGetValue(stick.Player.Team, out Timer highStickTimer);
                             highStickTimer.Change(Timeout.Infinite, Timeout.Infinite);
 
-                            SendChat(Rule.HighStick, stick.Player.Team, true);
-                            _lastStoppageReason = Rule.HighStick;
-                            DoFaceoff(RefSignals.GetSignalConstant(true, stick.Player.Team), RefSignals.HIGHSTICK_REF);
+                            CallHighStick(stick.Player.Team);
                         }
                     }
 

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -1610,6 +1610,8 @@ namespace oomtm450PuckMod_Ruleset {
                         else {
                             string lastPlayerOnPuckSteamId = _lastPlayerOnPuckSteamId[_lastPlayerOnPuckTeam];
                             bool playerTouched = _playersOnPuckDateTime.TryGetValue(lastPlayerOnPuckSteamId, out var lastTouchDateTime);
+                            if (!playerTouched)
+                                lastTouchDateTime = (_lastPlayerOnPuckTeam, DateTime.MinValue);
 
                             string lastPlayerOnPuckOtherTeamSteamId = _lastPlayerOnPuckSteamId[TeamFunc.GetOtherTeam(_lastPlayerOnPuckTeam)];
                             bool playerTouchedOtherTeam = _playersOnPuckDateTime.TryGetValue(lastPlayerOnPuckOtherTeamSteamId, out var lastTouchOtherTeamDateTime);
@@ -1623,8 +1625,10 @@ namespace oomtm450PuckMod_Ruleset {
 
                             Logging.Log("_puckDeflectedDateTimeSinceLastTouch : " + _puckDeflectedDateTimeSinceLastTouch.ToString("HH:mm:ss.fffffff"), ServerConfig, true); // TODO
 
-                            Logging.Log("lastTouchDateTime.LastTouchDateTime : " + lastTouchDateTime.LastTouchDateTime.ToString("HH:mm:ss.fffffff"), ServerConfig, true); // TODO
-                            Logging.Log("lastTouchOtherTeamDateTime.LastTouchDateTime : " + lastTouchOtherTeamDateTime.LastTouchDateTime.ToString("HH:mm:ss.fffffff"), ServerConfig, true); // TODO
+                            if (playerTouched)
+                                Logging.Log("lastTouchDateTime.LastTouchDateTime : " + lastTouchDateTime.LastTouchDateTime.ToString("HH:mm:ss.fffffff"), ServerConfig, true); // TODO
+                            if (playerTouchedOtherTeam)
+                                Logging.Log("lastTouchOtherTeamDateTime.LastTouchDateTime : " + lastTouchOtherTeamDateTime.LastTouchDateTime.ToString("HH:mm:ss.fffffff"), ServerConfig, true); // TODO
 
                             Logging.Log($"_puckDeflectedDateTimeSinceLastTouch > lastTouchDateTime.LastTouchDateTime : " + (_puckDeflectedDateTimeSinceLastTouch > lastTouchDateTime.LastTouchDateTime), ServerConfig, true); // TODO
 

--- a/Ruleset/Ruleset.cs
+++ b/Ruleset/Ruleset.cs
@@ -1136,15 +1136,15 @@ namespace oomtm450PuckMod_Ruleset {
 
                         Vector3 dot = Faceoff.GetFaceoffDot(NextFaceoffSpot, _arenaScaleX, _arenaScaleZ);
 
-                        List<string> claimedPositionsBlue = GetClaimedPositions(PlayerTeam.Blue);
-                        List<string> claimedPositionsRed = GetClaimedPositions(PlayerTeam.Red);
+                        List<(string Position, bool IsPenalized)> claimedPositionsBlue = GetClaimedPositions(PlayerTeam.Blue);
+                        List<(string Position, bool IsPenalized)> claimedPositionsRed = GetClaimedPositions(PlayerTeam.Red);
 
                         List<Player> players = PlayerManager.Instance.GetPlayers();
                         foreach (Player player in players) {
                             if (!Codebase.PlayerFunc.IsPlayerPlaying(player) || player.Team == PlayerTeam.Spectator || player.Team == PlayerTeam.None || PenaltyModule.PositionIsPenalized[player.Team][player.PlayerPosition.Name])
                                 continue;
 
-                            List<string> claimedPositions;
+                            List<(string Position, bool IsPenalized)> claimedPositions;
                             if (player.Team == PlayerTeam.Blue)
                                 claimedPositions = claimedPositionsBlue;
                             else

--- a/Sounds/Configs/ClientConfig.cs
+++ b/Sounds/Configs/ClientConfig.cs
@@ -29,6 +29,11 @@ namespace oomtm450PuckMod_Sounds.Configs {
         public bool LogInfo { get; set; } = true;
 
         /// <summary>
+        /// Bool, true if the mod has to be disabled.
+        /// </summary>
+        public bool DisableMod { get; set; } = false;
+
+        /// <summary>
         /// Bool, true if the music must be played ingame.
         /// </summary>
         public bool Music { get; set; } = true;

--- a/Sounds/Sounds.cs
+++ b/Sounds/Sounds.cs
@@ -165,7 +165,7 @@ namespace oomtm450PuckMod_Sounds {
             public static bool Prefix(GameState oldGameState, GameState newGameState) {
                 try {
                     // If this is not the server, do not use the patch.
-                    if (!ServerFunc.IsDedicatedServer() || !_logic || oldGameState.Phase == newGameState.Phase || !ServerConfig.EnableMusic || ClientConfig.DisableMod)
+                    if (!ServerFunc.IsDedicatedServer() || !_logic || oldGameState.Phase == newGameState.Phase || !ServerConfig.EnableMusic)
                         return true;
 
                     if (newGameState.Phase == GamePhase.BlueScore) {
@@ -584,6 +584,18 @@ namespace oomtm450PuckMod_Sounds {
                     }
 
                     if (_extraSoundsToLoad.Count != 0 && _soundsSystem != null) {
+                        if (_soundsSystem.Errors.Count != 0) {
+                            Logging.LogError($"There was an error when initializing {nameof(_soundsSystem)}.", ClientConfig);
+                            foreach (string error in _soundsSystem.Errors)
+                                Logging.LogError(error, ClientConfig);
+                        }
+                        if (_soundsSystem.Warnings.Count != 0) {
+                            Logging.LogError($"There was a warning when initializing {nameof(_soundsSystem)}.", ClientConfig);
+                            foreach (string warning in _soundsSystem.Warnings)
+                                Logging.LogError(warning, ClientConfig);
+                        }
+                        _soundsSystem.Warnings.Clear();
+
                         string path = _extraSoundsToLoad.First();
                         if (_soundsSystem.LoadSounds(ClientConfig.CustomGoalHorns, path))
                             _extraSoundsToLoad.Remove(path);
@@ -1127,6 +1139,12 @@ namespace oomtm450PuckMod_Sounds {
                             foreach (string error in _soundsSystem.Errors)
                                 Logging.LogError(error, ClientConfig);
                         }
+                        if (_soundsSystem.Warnings.Count != 0) {
+                            Logging.LogError($"There was a warning when initializing {nameof(_soundsSystem)}.", ClientConfig);
+                            foreach (string warning in _soundsSystem.Warnings)
+                                Logging.LogError(warning, ClientConfig);
+                        }
+                        _soundsSystem.Warnings.Clear();
 
                         if (dataStr == Codebase.SoundsSystem.MUSIC) {
                             if (!string.IsNullOrEmpty(_currentMusicPlaying))
@@ -1153,7 +1171,7 @@ namespace oomtm450PuckMod_Sounds {
         }
 
         private static void PlayFaceoffMusic() {
-            if (!ServerConfig.EnableMusic || ClientConfig.DisableMod)
+            if (!ServerConfig.EnableMusic)
                 return;
 
             if (!_hasPlayedLastMinuteMusic && GameManager.Instance.Tick <= 60 && GameManager.Instance.GameState.Value.Period == 3) {

--- a/Sounds/Sounds.cs
+++ b/Sounds/Sounds.cs
@@ -165,7 +165,7 @@ namespace oomtm450PuckMod_Sounds {
             public static bool Prefix(GameState oldGameState, GameState newGameState) {
                 try {
                     // If this is not the server, do not use the patch.
-                    if (!ServerFunc.IsDedicatedServer() || !_logic || oldGameState.Phase == newGameState.Phase || !ServerConfig.EnableMusic)
+                    if (!ServerFunc.IsDedicatedServer() || !_logic || oldGameState.Phase == newGameState.Phase || !ServerConfig.EnableMusic || ClientConfig.DisableMod)
                         return true;
 
                     if (newGameState.Phase == GamePhase.BlueScore) {
@@ -327,7 +327,7 @@ namespace oomtm450PuckMod_Sounds {
             public static bool Prefix(SynchronizedAudio __instance, ref float volume, ref float pitch, ref bool isOneShot, int clipIndex, float time, bool fadeIn, float fadeInDuration, bool fadeOut, float fadeOutDuration, float duration, RpcParams rpcParams) {
                 try {
                     // If this is the server or the custom goal horns are turned off, do not use the patch.
-                    if (ServerFunc.IsDedicatedServer() || !ClientConfig.CustomGoalHorns)
+                    if (ServerFunc.IsDedicatedServer() || !ClientConfig.CustomGoalHorns || ClientConfig.DisableMod)
                         return true;
 
                     AudioSource audioSource = SystemFunc.GetPrivateField<AudioSource>(typeof(SynchronizedAudio), __instance, "audioSource");
@@ -561,7 +561,7 @@ namespace oomtm450PuckMod_Sounds {
             public static void Postfix() {
                 try {
                     // If this is the server, do not use the patch.
-                    if (ServerFunc.IsDedicatedServer() || NetworkManager.Singleton == null)
+                    if (ServerFunc.IsDedicatedServer() || NetworkManager.Singleton == null || ClientConfig.DisableMod)
                         return;
 
                     if (!_hasRegisteredWithNamedMessageHandler || !_serverHasResponded) {
@@ -747,7 +747,7 @@ namespace oomtm450PuckMod_Sounds {
                             break;
 
                         case Codebase.SoundsSystem.PLAY_SOUND:
-                            if (value == Codebase.SoundsSystem.FACEOFF_MUSIC && ServerConfig.EnableMusic)
+                            if (value == Codebase.SoundsSystem.FACEOFF_MUSIC)
                                 PlayFaceoffMusic();
                             break;
 
@@ -919,7 +919,7 @@ namespace oomtm450PuckMod_Sounds {
         /// Method that loads the assets for the client-side sounds.
         /// </summary>
         private static void LoadAssets() {
-            if (_soundsSystem == null) {
+            if (_soundsSystem == null && !ClientConfig.DisableMod) {
                 GameObject soundsGameObject = new GameObject(Constants.MOD_NAME + "_Sounds");
                 _soundsSystem = soundsGameObject.AddComponent<SoundsSystem>();
                 Logging.Log("SoundsSystem object was created.", ClientConfig);
@@ -994,7 +994,7 @@ namespace oomtm450PuckMod_Sounds {
                         break;
 
                     case Constants.SET_GOAL_HORN: // CLIENT-SIDE : Swap goal horn AudioSource clip for donor's chosen horn.
-                        if (_soundsSystem == null || !ClientConfig.CustomGoalHorns)
+                        if (_soundsSystem == null || !ClientConfig.CustomGoalHorns || ClientConfig.DisableMod)
                             break;
 
                         string[] setHornDataStrSplitted = dataStr.Split(';');
@@ -1006,7 +1006,7 @@ namespace oomtm450PuckMod_Sounds {
                         break;
 
                     case Constants.RESET_GOAL_HORN: // CLIENT-SIDE : Swap goal horn AudioSource clip for defaults horn.
-                        if (_soundsSystem == null || !ClientConfig.CustomGoalHorns)
+                        if (_soundsSystem == null || !ClientConfig.CustomGoalHorns || ClientConfig.DisableMod)
                             break;
 
                         _soundsSystem.SetGoalHorns();
@@ -1139,7 +1139,8 @@ namespace oomtm450PuckMod_Sounds {
                         break;
 
                     case Codebase.SoundsSystem.LOAD_EXTRA_SOUNDS:
-                        _extraSoundsToLoad.Add(dataStr);
+                        if (!ClientConfig.DisableMod)
+                            _extraSoundsToLoad.Add(dataStr);
                         break;
 
                     default:
@@ -1152,7 +1153,7 @@ namespace oomtm450PuckMod_Sounds {
         }
 
         private static void PlayFaceoffMusic() {
-            if (!ServerConfig.EnableMusic)
+            if (!ServerConfig.EnableMusic || ClientConfig.DisableMod)
                 return;
 
             if (!_hasPlayedLastMinuteMusic && GameManager.Instance.Tick <= 60 && GameManager.Instance.GameState.Value.Period == 3) {

--- a/Sounds/SoundsSystem.cs
+++ b/Sounds/SoundsSystem.cs
@@ -82,7 +82,7 @@ namespace oomtm450PuckMod_Sounds {
                 if (_audioClips.Count == 0)
                     DontDestroyOnLoad(gameObject);
 
-                string[] splittedPath = new string[] { path };
+                string[] splittedPath = new string[] { path, };
                 if (path.Contains('/')) // Linux path
                     splittedPath = path.Split('/');
                 else // Windows path
@@ -94,7 +94,7 @@ namespace oomtm450PuckMod_Sounds {
                     lastIndexOf = rootPath.LastIndexOf('\\');
 
                 rootPath = rootPath.Substring(0, lastIndexOf);
-                string fullPath = Path.Combine(Path.Combine(rootPath, splittedPath[splittedPath.Count() - 2]), splittedPath.Last());
+                string fullPath = Path.Combine(Path.Combine(rootPath, splittedPath[splittedPath.Length - 2]), splittedPath.Last());
 
                 if (!Directory.Exists(fullPath)) {
                     Logging.LogError($"Sounds not found at: {fullPath}", Sounds.ClientConfig);
@@ -137,7 +137,9 @@ namespace oomtm450PuckMod_Sounds {
         /// <param name="setCustomGoalHorns">Bool, true if the custom goal horns has to be set.</param>
         /// <returns>IEnumerator, enumerator used by the Coroutine to load the audio clips.</returns>
         private async Awaitable GetAudioClipsAsync(string path, bool setCustomGoalHorns, CancellationToken cancellationToken) {
-            string[] files = Array.Empty<string>();
+            await Awaitable.BackgroundThreadAsync();
+
+            IEnumerable<string> files = null;
 
             bool tryGetFiles = true;
             int tryGetFilesCount = 0;
@@ -176,18 +178,23 @@ namespace oomtm450PuckMod_Sounds {
                     }
                 }
                 catch (Exception ex) {
+                    tryGetFiles = true;
                     Warnings.Add($"Sounds.{nameof(GetAudioClipsAsync)} 2 : {ex}");
                 }
 
-                if (++tryGetFilesCount > 5) {
+                if (tryGetFiles) {
+                    await Awaitable.BackgroundThreadAsync();
                     IsLoading = false;
+                    await Awaitable.MainThreadAsync();
                     Warnings.Add($"{nameof(tryGetFilesCount)} has gone over the threshold, check the other warnings.");
                     return;
                 }
 
                 if (tryGetFiles)
-                    await Awaitable.WaitForSecondsAsync(1f, cancellationToken);
+                    await Task.Delay(1000, cancellationToken);
             }
+
+            await Awaitable.MainThreadAsync();
 
             foreach (string file in files) {
                 string filePath = new Uri(Path.GetFullPath(file)).LocalPath;
@@ -205,7 +212,9 @@ namespace oomtm450PuckMod_Sounds {
 
                     while (!asyncOp.isDone) {
                         if (cancellationToken.IsCancellationRequested) {
+                            await Awaitable.BackgroundThreadAsync();
                             IsLoading = false;
+                            await Awaitable.MainThreadAsync();
                             return;
                         }
 
@@ -216,11 +225,7 @@ namespace oomtm450PuckMod_Sounds {
                         Warnings.Add(webRequest.error);
                     else {
                         try {
-                            await Awaitable.BackgroundThreadAsync();
-
                             AudioClip clip = downloadHandler.audioClip;
-
-                            await Awaitable.MainThreadAsync();
 
                             if (!clip) {
                                 Errors.Add($"Sounds.{nameof(GetAudioClipsAsync)} clip null.");
@@ -249,9 +254,9 @@ namespace oomtm450PuckMod_Sounds {
                         catch (Exception ex) {
                             Errors.Add($"Sounds.{nameof(GetAudioClipsAsync)} 3 : {ex}");
 
-                            // Safeguard: Ensure you are returned to the main thread even if a failure occurs
-                            await Awaitable.MainThreadAsync();
+                            await Awaitable.BackgroundThreadAsync();
                             IsLoading = false;
+                            await Awaitable.MainThreadAsync();
                             return;
                         }
                     }
@@ -259,8 +264,6 @@ namespace oomtm450PuckMod_Sounds {
 
                 await Awaitable.NextFrameAsync(cancellationToken);
             }
-
-            await Awaitable.NextFrameAsync(cancellationToken);
 
             try {
                 foreach (string key in currentConfig.Keys)
@@ -272,8 +275,6 @@ namespace oomtm450PuckMod_Sounds {
             catch (Exception ex) {
                 Warnings.Add($"Sounds.{nameof(GetAudioClipsAsync)} 4 : {ex}");
             }
-
-            await Awaitable.NextFrameAsync(cancellationToken);
 
             try {
                 if (setCustomGoalHorns)
@@ -291,7 +292,9 @@ namespace oomtm450PuckMod_Sounds {
                 Errors.Add($"Sounds.{nameof(GetAudioClipsAsync)} 6 : {ex}");
             }
 
+            await Awaitable.BackgroundThreadAsync();
             IsLoading = false;
+            await Awaitable.MainThreadAsync();
         }
 
         private void AddClipNameToCorrectList(string clipName, int weight = DEFAULT_SOUND_WEIGHT) {

--- a/Sounds/SoundsSystem.cs
+++ b/Sounds/SoundsSystem.cs
@@ -74,6 +74,9 @@ namespace oomtm450PuckMod_Sounds {
                 if (IsLoading)
                     return false;
 
+                if (Sounds.ClientConfig.DisableMod)
+                    return true;
+
                 IsLoading = true;
 
                 if (_audioClips.Count == 0)
@@ -137,6 +140,7 @@ namespace oomtm450PuckMod_Sounds {
             string[] files = Array.Empty<string>();
 
             bool tryGetFiles = true;
+            int tryGetFilesCount = 0;
             string jsonPath = "";
             Dictionary<string, SoundSettings> currentConfig = new Dictionary<string, SoundSettings>();
             bool currentConfigWasEmpty = false;
@@ -175,8 +179,14 @@ namespace oomtm450PuckMod_Sounds {
                     Warnings.Add($"Sounds.{nameof(GetAudioClipsAsync)} 2 : {ex}");
                 }
 
+                if (++tryGetFilesCount > 5) {
+                    IsLoading = false;
+                    Warnings.Add($"{nameof(tryGetFilesCount)} has gone over the threshold, check the other warnings.");
+                    return;
+                }
+
                 if (tryGetFiles)
-                    await Awaitable.NextFrameAsync(cancellationToken);
+                    await Awaitable.WaitForSecondsAsync(1f, cancellationToken);
             }
 
             foreach (string file in files) {
@@ -194,10 +204,12 @@ namespace oomtm450PuckMod_Sounds {
                     var asyncOp = webRequest.SendWebRequest();
 
                     while (!asyncOp.isDone) {
-                        if (cancellationToken.IsCancellationRequested)
+                        if (cancellationToken.IsCancellationRequested) {
+                            IsLoading = false;
                             return;
+                        }
 
-                        await Awaitable.NextFrameAsync(cancellationToken);
+                        await Awaitable.WaitForSecondsAsync(0.1f, cancellationToken);
                     }
 
                     if (webRequest.result != UnityWebRequest.Result.Success)
@@ -239,6 +251,7 @@ namespace oomtm450PuckMod_Sounds {
 
                             // Safeguard: Ensure you are returned to the main thread even if a failure occurs
                             await Awaitable.MainThreadAsync();
+                            IsLoading = false;
                             return;
                         }
                     }

--- a/Stats/Configs/ServerConfig.cs
+++ b/Stats/Configs/ServerConfig.cs
@@ -58,7 +58,7 @@ namespace oomtm450PuckMod_Stats.Configs {
         /// <summary>
         /// Int, number of milliseconds for a puck to not be considered tipped by a player's stick.
         /// </summary>
-        public int MaxTippedMilliseconds { get; set; } = 34;
+        public int MaxTippedMilliseconds { get; set; } = 32;
 
         /// <summary>
         /// Int, number of milliseconds for a possession to be considered with challenge.

--- a/Stats/Configs/ServerConfig.cs
+++ b/Stats/Configs/ServerConfig.cs
@@ -58,7 +58,7 @@ namespace oomtm450PuckMod_Stats.Configs {
         /// <summary>
         /// Int, number of milliseconds for a puck to not be considered tipped by a player's stick.
         /// </summary>
-        public int MaxTippedMilliseconds { get; set; } = 32;
+        public int MaxTippedMilliseconds { get; set; } = 33;
 
         /// <summary>
         /// Int, number of milliseconds for a possession to be considered with challenge.

--- a/Stats/PuckRaycast.cs
+++ b/Stats/PuckRaycast.cs
@@ -7,11 +7,11 @@ namespace oomtm450PuckMod_Stats {
     /// Class containing code for the puck raycasts with the goal trigger to know if the puck is going towards the net or not.
     /// </summary>
     internal class PuckRaycast : MonoBehaviour {
-        private const int CHECK_EVERY_X_FRAMES = 6;
-        //private readonly Vector3 TOP_VECTOR = new Vector3(0, 0.175f, 0);
-        private readonly Vector3 ABOVE_GROUND_VECTOR = new Vector3(0, 0.001f, 0);
+        private const int CHECK_EVERY_X_FRAMES = 4;
+        //private Vector3 TOP_VECTOR = new Vector3(0, 0.175f, 0);
+        private Vector3 ABOVE_GROUND_VECTOR = new Vector3(0, 0.001f, 0);
         private readonly float RIGHT_OFFSET = Codebase.Constants.PUCK_RADIUS + 0.02f;
-        private readonly Vector3 BOTTOM_VECTOR = new Vector3(0, -0.6f, 0);
+        private Vector3 BOTTOM_VECTOR = new Vector3(0, -0.6f, 0);
         private readonly LayerMask _goalTriggerlayerMask = GetLayerMask("Goal Trigger"); // 15
 
         private Ray _rayBottomLeft;
@@ -26,8 +26,8 @@ namespace oomtm450PuckMod_Stats {
         private Ray _rayFarBottomRight;
         //private LineRenderer _lineRendererFarBottomRight;
 
-        //private readonly Material _noHitMaterial = new Material(Shader.Find("Shader Graphs/Stick Shader"));
-        //private readonly Material _hitMaterial = new Material(Shader.Find("Shader Graphs/Stick Simple"));
+        //private Material _noHitMaterial;
+        //private Material _hitMaterial;
 
         private Vector3 _startingPosition;
 
@@ -39,20 +39,34 @@ namespace oomtm450PuckMod_Stats {
         };
 
         internal void Start() {
-            /*_lineRendererBottomLeft = CreateLineRenderer();
+            ABOVE_GROUND_VECTOR = new Vector3(ABOVE_GROUND_VECTOR.x, ABOVE_GROUND_VECTOR.y + Stats.ArenaOffsetY, ABOVE_GROUND_VECTOR.z);
+            BOTTOM_VECTOR = new Vector3(BOTTOM_VECTOR.x, BOTTOM_VECTOR.y + Stats.ArenaOffsetY, BOTTOM_VECTOR.z);
+            //TOP_VECTOR = new Vector3(TOP_VECTOR.x, TOP_VECTOR.y + Stats.ArenaOffsetY, TOP_VECTOR.z);
+
+            /*Shader testShader = Shader.Find("Universal Render Pipeline/Lit");
+            if (testShader == null)
+                testShader = Shader.Find("HDRP/Lit");
+
+            _noHitMaterial = new Material(testShader);
+            _noHitMaterial.color = Color.white;
+
+            _hitMaterial = new Material(testShader);
+            _hitMaterial.color = Color.red;
+
+            _lineRendererBottomLeft = CreateLineRenderer();
             _lineRendererBottomRight = CreateLineRenderer();
             _lineRendererFarBottomLeft = CreateLineRenderer();
             _lineRendererFarBottomRight = CreateLineRenderer();*/
 
             ResetStartingPosition();
             _increment = CHECK_EVERY_X_FRAMES - 1;
-            Update();
+            FixedUpdate();
         }
 
         /// <summary>
         /// Method that updates every frame to check for collision with the puck's raycasts and a goal trigger.
         /// </summary>
-        internal void Update() {
+        internal void FixedUpdate() {
             if (++_increment == CHECK_EVERY_X_FRAMES) {
                 foreach (PlayerTeam key in new List<PlayerTeam>(PuckIsGoingToNet.Keys))
                     PuckIsGoingToNet[key] = false;
@@ -112,27 +126,26 @@ namespace oomtm450PuckMod_Stats {
                             return;
                         /*else {
                             _lineRendererFarBottomRight.material = _hitMaterial;
-                            //Logging.Log("Far bottom right ray has hit !", Stats.ServerConfig, true);
+                            Logging.Log("Far bottom right ray has hit !", Stats.ServerConfig, true);
                         }*/
                     }
                     /*else {
                         _lineRendererFarBottomLeft.material = _hitMaterial;
-                        //Logging.Log("Far bottom left ray has hit !", Stats.ServerConfig, true);
+                        Logging.Log("Far bottom left ray has hit !", Stats.ServerConfig, true);
                     }*/
                 }
                 /*else {
                     _lineRendererBottomRight.material = _hitMaterial;
-                    //Logging.Log("Bottom right ray has hit !", Stats.ServerConfig, true);
+                    Logging.Log("Bottom right ray has hit !", Stats.ServerConfig, true);
                 }*/
             }
             /*else {
                 _lineRendererBottomLeft.material = _hitMaterial;
-                //Logging.Log("Bottom left ray has hit !", Stats.ServerConfig, true);
+                Logging.Log("Bottom left ray has hit !", Stats.ServerConfig, true);
             }*/
 
             Goal goal = SystemFunc.GetPrivateField<Goal>(typeof(GoalTrigger), hit.collider.gameObject.GetComponent<GoalTrigger>(), "goal");
-            PlayerTeam team = SystemFunc.GetPrivateField<PlayerTeam>(typeof(Goal), goal, "Team");
-            PuckIsGoingToNet[team] = hasHit;
+            PuckIsGoingToNet[goal.Team] = hasHit;
         }
 
         private static LayerMask GetLayerMask(string layerName) {

--- a/Stats/Stats.cs
+++ b/Stats/Stats.cs
@@ -377,8 +377,7 @@ namespace oomtm450PuckMod_Stats {
                     if (!ServerFunc.IsDedicatedServer() || isReplay || (GameManager.Instance.Phase != GamePhase.Play && GameManager.Instance.Phase != GamePhase.FaceOff))
                         return;
 
-                    __result.gameObject.AddComponent<PuckRaycast>();
-                    _puckRaycast = __result.gameObject.GetComponent<PuckRaycast>();
+                    _puckRaycast = __result.gameObject.AddComponent<PuckRaycast>();
                 }
                 catch (Exception ex) {
                     Logging.LogError($"Error in {nameof(PuckManager_Server_SpawnPuck_Patch)} Postfix().\n{ex}", ServerConfig);

--- a/Stats/Stats.cs
+++ b/Stats/Stats.cs
@@ -181,7 +181,7 @@ namespace oomtm450PuckMod_Stats {
         private static float _arenaScaleZ = 1f;
 
         private static float _arenaOffsetX = 0;
-        private static float _arenaOffsetY = 0;
+        internal static float ArenaOffsetY { get; set; } = 0;
         private static float _arenaOffsetZ = 0;
 
         /// <summary>
@@ -1087,7 +1087,7 @@ namespace oomtm450PuckMod_Stats {
                     _lastTeamOnPuckTipIncluded = stick.Player.Team;
 
                     if (!PuckFunc.PuckIsTipped(playerSteamId, ServerConfig.MaxTippedMilliseconds, _playersCurrentPuckTouch, _lastTimeOnCollisionStayOrExitWasCalled,
-                        __instance.Rigidbody.transform.position.y, ServerConfig.PuckIceContactHeight + _arenaOffsetY)) {
+                        __instance.Rigidbody.transform.position.y, ServerConfig.PuckIceContactHeight + ArenaOffsetY)) {
                         //_lastTeamOnPuck = stick.Player.Team;
                         _lastPlayerOnPuckSteamId[stick.Player.Team] = (playerSteamId, DateTime.UtcNow);
                     }
@@ -1486,7 +1486,7 @@ namespace oomtm450PuckMod_Stats {
 
                         case "ArenaOffsetY":
                             double arenaOffsetY = double.Parse(kvp.Value.ToString(), CultureInfo.InvariantCulture);
-                            _arenaOffsetY = (float)arenaOffsetY;
+                            ArenaOffsetY = (float)arenaOffsetY;
                             break;
 
                         case "ArenaOffsetZ":

--- a/Stats/Stats.cs
+++ b/Stats/Stats.cs
@@ -806,7 +806,7 @@ namespace oomtm450PuckMod_Stats {
         [HarmonyPatch(typeof(UIScoreboard), nameof(UIScoreboard.AddPlayer))]
         public class UIScoreboard_AddPlayer_Patch {
             [HarmonyPostfix]
-            public static void Postfix(UIScoreboard __instance, Player player) {
+            public static void Postfix(UIScoreboard __instance, Player player) { // TODO : Fix this.
                 try {
                     string playerSteamId = player.SteamId.Value.ToString();
                     if (!string.IsNullOrEmpty(playerSteamId) && _stars.Values.Contains(playerSteamId)) {
@@ -1256,7 +1256,7 @@ namespace oomtm450PuckMod_Stats {
         /// Class that patches GetChatMessagePrefix event from UIChat.
         /// </summary>
         [HarmonyPatch(typeof(UIChat), "GetChatMessagePrefix")]
-        public static class UIChat_GetChatMessagePrefix_Patch {
+        public static class UIChat_GetChatMessagePrefix_Patch { // TODO : Fix this.
             public static void Postfix(ChatMessage chatMessage, ref string __result) {
                 if (chatMessage.IsSystem)
                     return;

--- a/Stats/Stats.cs
+++ b/Stats/Stats.cs
@@ -1826,7 +1826,7 @@ namespace oomtm450PuckMod_Stats {
 
                 if (PlayerFunc.IsGoalie(player)) {
                     if (_savePerc.TryGetValue(steamId, out var saveValues))
-                        starPoints[steamId] += (((double)saveValues.Saves) / ((double)saveValues.Shots)) - 0.450d * ((double)saveValues.Saves) * 40d;
+                        starPoints[steamId] += (((double)saveValues.Saves) / ((double)saveValues.Shots)) - 0.450d * ((double)saveValues.Saves) * 45d;
 
                     if (_sog.TryGetValue(steamId, out int shots))
                         starPoints[steamId] += ((double)shots) * 1d;

--- a/Stats/Stats.cs
+++ b/Stats/Stats.cs
@@ -392,8 +392,11 @@ namespace oomtm450PuckMod_Stats {
         public class BaseGameMode_ScoreGoal_Patch {
             [HarmonyPrefix]
             [HarmonyPriority(Priority.VeryLow)]
-            public static bool Prefix(PlayerTeam byTeam, ref Player goalPlayer, ref Player assistPlayer, ref Player secondAssistPlayer, Puck puck) {
+            public static bool Prefix(PlayerTeam byTeam, ref Player goalPlayer, ref Player assistPlayer, ref Player secondAssistPlayer, Puck puck, bool __runOriginal) {
                 try {
+                    if (!__runOriginal)
+                        return false;
+
                     // If this is not the server or game is not started, do not use the patch.
                     if (!ServerFunc.IsDedicatedServer() || !_logic)
                         return true;

--- a/Stats/Stats.cs
+++ b/Stats/Stats.cs
@@ -389,9 +389,9 @@ namespace oomtm450PuckMod_Stats {
         /// Class that patches the ScoreGoal event from BaseGameMode.
         /// </summary>
         [HarmonyPatch(typeof(BaseGameMode<BaseGameModeConfig>), "ScoreGoal")]
-        [HarmonyPriority(Priority.VeryLow)]
         public class BaseGameMode_ScoreGoal_Patch {
             [HarmonyPrefix]
+            [HarmonyPriority(Priority.VeryLow)]
             public static bool Prefix(PlayerTeam byTeam, ref Player goalPlayer, ref Player assistPlayer, ref Player secondAssistPlayer, Puck puck) {
                 try {
                     // If this is not the server or game is not started, do not use the patch.

--- a/Stats/Stats.cs
+++ b/Stats/Stats.cs
@@ -396,7 +396,50 @@ namespace oomtm450PuckMod_Stats {
             public static bool Prefix(PlayerTeam byTeam, ref Player goalPlayer, ref Player assistPlayer, ref Player secondAssistPlayer, Puck puck) {
                 try {
                     // If this is not the server or game is not started, do not use the patch.
-                    if (!ServerFunc.IsDedicatedServer() || RulesetModEnabled() || !_logic)
+                    if (!ServerFunc.IsDedicatedServer() || !_logic)
+                        return true;
+
+                    try {
+                        foreach (Player player in PlayerManager.Instance.GetPlayers()) {
+                            if (!PlayerFunc.IsPlayerPlaying(player) || PlayerFunc.IsGoalie(player))
+                                continue;
+
+                            string playerSteamId = player.SteamId.Value.ToString();
+                            if (!_plusMinus.TryGetValue(playerSteamId, out int _))
+                                _plusMinus.Add(playerSteamId, 0);
+
+                            if (player.Team == byTeam)
+                                _plusMinus[playerSteamId] += 1;
+                            else
+                                _plusMinus[playerSteamId] -= 1;
+
+                            NetworkCommunication.SendDataToAll(Codebase.Constants.PLUSMINUS + playerSteamId, _plusMinus[playerSteamId].ToString(), Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
+                            LogPlusMinus(playerSteamId, _plusMinus[playerSteamId]);
+                        }
+
+                        LockList<string> goalsList, assistsList;
+
+                        if (byTeam == PlayerTeam.Blue) {
+                            goalsList = _blueGoals;
+                            assistsList = _blueAssists;
+                        }
+                        else {
+                            goalsList = _redGoals;
+                            assistsList = _redAssists;
+                        }
+
+                        if (goalPlayer != null)
+                            goalsList.Add(goalPlayer.SteamId.Value.ToString());
+                        if (assistPlayer != null)
+                            assistsList.Add(assistPlayer.SteamId.Value.ToString());
+                        if (secondAssistPlayer != null)
+                            assistsList.Add(secondAssistPlayer.SteamId.Value.ToString());
+                    }
+                    catch (Exception ex) {
+                        Logging.LogError($"Error in {nameof(BaseGameMode_ScoreGoal_Patch)} Prefix() 1.\n{ex}", ServerConfig);
+                    }
+
+                    if (RulesetModEnabled())
                         return true;
 
                     if (goalPlayer != null) {
@@ -429,47 +472,7 @@ namespace oomtm450PuckMod_Stats {
                     }
                 }
                 catch (Exception ex) {
-                    Logging.LogError($"Error in {nameof(BaseGameMode_ScoreGoal_Patch)} Prefix() 1.\n{ex}", ServerConfig);
-                }
-
-                try {
-                    foreach (Player player in PlayerManager.Instance.GetPlayers()) {
-                        if (!PlayerFunc.IsPlayerPlaying(player) || PlayerFunc.IsGoalie(player))
-                            continue;
-
-                        string playerSteamId = player.SteamId.Value.ToString();
-                        if (!_plusMinus.TryGetValue(playerSteamId, out int _))
-                            _plusMinus.Add(playerSteamId, 0);
-
-                        if (player.Team == byTeam)
-                            _plusMinus[playerSteamId] += 1;
-                        else
-                            _plusMinus[playerSteamId] -= 1;
-
-                        NetworkCommunication.SendDataToAll(Codebase.Constants.PLUSMINUS + playerSteamId, _plusMinus[playerSteamId].ToString(), Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
-                        LogPlusMinus(playerSteamId, _plusMinus[playerSteamId]);
-                    }
-
-                    LockList<string> goalsList, assistsList;
-
-                    if (byTeam == PlayerTeam.Blue) {
-                        goalsList = _blueGoals;
-                        assistsList = _blueAssists;
-                    }
-                    else {
-                        goalsList = _redGoals;
-                        assistsList = _redAssists;
-                    }
-
-                    if (goalPlayer != null)
-                        goalsList.Add(goalPlayer.SteamId.Value.ToString());
-                    if (assistPlayer != null)
-                        assistsList.Add(assistPlayer.SteamId.Value.ToString());
-                    if (secondAssistPlayer != null)
-                        assistsList.Add(secondAssistPlayer.SteamId.Value.ToString());
-                }
-                catch (Exception ex) {
-                    Logging.LogError($"Error in {nameof(BaseGameMode_ScoreGoal_Patch)} Postfix() 2.\n{ex}", ServerConfig);
+                    Logging.LogError($"Error in {nameof(BaseGameMode_ScoreGoal_Patch)} Prefix() 2.\n{ex}", ServerConfig);
                 }
 
                 return true;

--- a/Stats/Stats.cs
+++ b/Stats/Stats.cs
@@ -1826,7 +1826,7 @@ namespace oomtm450PuckMod_Stats {
 
                 if (PlayerFunc.IsGoalie(player)) {
                     if (_savePerc.TryGetValue(steamId, out var saveValues))
-                        starPoints[steamId] += (((double)saveValues.Saves) / ((double)saveValues.Shots)) - 0.450d * ((double)saveValues.Saves) * 45d;
+                        starPoints[steamId] += (((double)saveValues.Saves) / ((double)saveValues.Shots)) - 0.300d * ((double)saveValues.Saves) * 45d;
 
                     if (_sog.TryGetValue(steamId, out int shots))
                         starPoints[steamId] += ((double)shots) * 1d;


### PR DESCRIPTION
**Ruleset**
Fixed crash on delay of game.
Fixed delay of game by goalie.
Fixed pending penalty on high stick.
Adjusted tip values.
Tentative fix for refused goal on penalty on the other team.
Fixed two players on the same position on faceoff when penalized player leave.
Fixed penalties on same play going over the maximum set by MaxPenalizedPlayersPerTeam.
Removed jumping from the high stick logic. (Rulebook specifies high stick to be at normal shoulder height)
Adjusted delay of game values.
Refactoring.

**Stats**
Fixed goals, assists and plus minuses not being counted.
Improved PuckRaycast for SOG detection.
Adjusted tip values.
Adjusted goalie star logic.

**Sounds**
Fixed game hanging infinitely.
Added DisableMod option for testing if Sounds is the one causing issues.