### PR TITLE
Sounds V0.4.2

### DIFF
--- a/Codebase/SystemFunc/SoundsSystem.cs
+++ b/Codebase/SystemFunc/SoundsSystem.cs
@@ -10,8 +10,9 @@
         internal const string ALL = "all";
         internal const string MUSIC = "music";
         internal const string WHISTLE = "whistle";
-        internal const string BLUEGOALHORN = "bluegoalhorn";
-        internal const string REDGOALHORN = "redgoalhorn";
+        internal const string GOAL_HORN = "goalhorn";
+        internal const string BLUE_GOAL_HORN = "blue" + GOAL_HORN;
+        internal const string RED_GOAL_HORN = "red" + GOAL_HORN;
         internal const string FACEOFF_MUSIC = "faceoffmusic";
         internal const string FACEOFF_MUSIC_DELAYED = FACEOFF_MUSIC + "d";
 

--- a/Sounds/Configs/ClientConfig.cs
+++ b/Sounds/Configs/ClientConfig.cs
@@ -84,11 +84,6 @@ namespace oomtm450PuckMod_Sounds.Configs {
         public bool WarmupMusic { get; set; } = true;
 
         /// <summary>
-        /// Bool, true if the server has authority on how loud each music has to be compared to each others. False if the client has authority.
-        /// </summary>
-        public bool UseServerPerMusicVolume { get; set; } = true;
-
-        /// <summary>
         /// String, name of the mod.
         /// </summary>
         [JsonIgnore]

--- a/Sounds/Configs/ClientConfig.cs
+++ b/Sounds/Configs/ClientConfig.cs
@@ -84,6 +84,11 @@ namespace oomtm450PuckMod_Sounds.Configs {
         public bool WarmupMusic { get; set; } = true;
 
         /// <summary>
+        /// Bool, true if the audio clips have to be created on play, then cached.
+        /// </summary>
+        public bool LazyLoading { get; set; } = true;
+
+        /// <summary>
         /// String, name of the mod.
         /// </summary>
         [JsonIgnore]

--- a/Sounds/Properties/AssemblyInfo.cs
+++ b/Sounds/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Numéro de build
 //      Révision
 //
-[assembly: AssemblyVersion("0.4.1.0")]
-[assembly: AssemblyFileVersion("0.4.1.0")]
+[assembly: AssemblyVersion("0.4.2.0")]
+[assembly: AssemblyFileVersion("0.4.2.0")]

--- a/Sounds/Sounds.cs
+++ b/Sounds/Sounds.cs
@@ -16,7 +16,7 @@ namespace oomtm450PuckMod_Sounds {
         /// <summary>
         /// Const string, version of the mod.
         /// </summary>
-        private static readonly string MOD_VERSION = "0.4.1";
+        private static readonly string MOD_VERSION = "0.4.2";
 
         /// <summary>
         /// List of string, last released versions of the mod.
@@ -31,6 +31,7 @@ namespace oomtm450PuckMod_Sounds {
             "0.2.3a",
             "0.3.0",
             "0.4.0",
+            "0.4.1",
         });
 
         /// <summary>
@@ -509,7 +510,7 @@ namespace oomtm450PuckMod_Sounds {
                                         if (ClientConfig.WarmupMusic && !((bool)enableWarmupMusic))
                                             _soundsSystem.StopAll();
                                         else if (!ClientConfig.WarmupMusic && (bool)enableWarmupMusic)
-                                            _soundsSystem.Play(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, 0, 0, true);
+                                            _ = _soundsSystem.PlayAsync(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, 0, 0, true);
                                     }
 
                                     ClientConfig.WarmupMusic = (bool)enableWarmupMusic;
@@ -1055,26 +1056,26 @@ namespace oomtm450PuckMod_Sounds {
                             if (string.IsNullOrEmpty(chosenSound))
                                 _currentMusicPlaying = SoundsSystem.GetRandomSound(_soundsSystem.BlueGoalMusicList, SoundsSystem.SoundType.BlueGoal, seed);
 
-                            _soundsSystem.Play(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.GoalMusicVolume, 2.25f);
+                            _ = _soundsSystem.PlayAsync(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.GoalMusicVolume, 2.25f);
                         }
                         else if (playSoundDataStrSplitted[0] == Codebase.SoundsSystem.RED_GOAL_MUSIC) {
                             if (string.IsNullOrEmpty(chosenSound))
                                 _currentMusicPlaying = SoundsSystem.GetRandomSound(_soundsSystem.RedGoalMusicList, SoundsSystem.SoundType.RedGoal, seed);
 
-                            _soundsSystem.Play(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.GoalMusicVolume, 2.25f);
+                            _ = _soundsSystem.PlayAsync(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.GoalMusicVolume, 2.25f);
                         }
                         else if (playSoundDataStrSplitted[0] == Codebase.SoundsSystem.BETWEEN_PERIODS_MUSIC) {
                             if (string.IsNullOrEmpty(chosenSound))
                                 _currentMusicPlaying = SoundsSystem.GetRandomSound(_soundsSystem.BetweenPeriodsMusicList, SoundsSystem.SoundType.BetweenPeriods, seed);
 
-                            _soundsSystem.Play(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.BetweenPeriodsMusicVolume, 1.5f);
+                            _ = _soundsSystem.PlayAsync(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.BetweenPeriodsMusicVolume, 1.5f);
                         }
                         else if (playSoundDataStrSplitted[0] == Codebase.SoundsSystem.WARMUP_MUSIC) {
                             if (string.IsNullOrEmpty(chosenSound))
                                 _currentMusicPlaying = SoundsSystem.GetRandomSound(_soundsSystem.WarmupMusicList, SoundsSystem.SoundType.Warmup, seed);
 
                             if (ClientConfig.WarmupMusic)
-                                _soundsSystem.Play(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.WarmupMusicVolume, 0, true);
+                                _ = _soundsSystem.PlayAsync(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.WarmupMusicVolume, 0, true);
                         }
                         else if (playSoundDataStrSplitted[0] == Codebase.SoundsSystem.LAST_MINUTE_MUSIC) {
                             if (string.IsNullOrEmpty(chosenSound))
@@ -1119,15 +1120,15 @@ namespace oomtm450PuckMod_Sounds {
                             if (string.IsNullOrEmpty(chosenSound))
                                 _currentMusicPlaying = SoundsSystem.GetRandomSound(_soundsSystem.GameOverMusicList, SoundsSystem.SoundType.None, seed);
 
-                            _soundsSystem.Play(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.GameOverMusicVolume, 0.5f);
+                            _ = _soundsSystem.PlayAsync(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.GameOverMusicVolume, 0.5f);
                         }
                         else if (playSoundDataStrSplitted[0] == Codebase.SoundsSystem.WHISTLE)
-                            _soundsSystem.Play(Codebase.SoundsSystem.WHISTLE, "");
+                            _ = _soundsSystem.PlayAsync(Codebase.SoundsSystem.WHISTLE, "");
 
                         if (isFaceoffMusic) {
                             if (string.IsNullOrEmpty(_currentMusicPlaying))
                                 _currentMusicPlaying = SoundsSystem.GetRandomSound(_soundsSystem.FaceoffMusicList, SoundsSystem.SoundType.Faceoff, seed);
-                            _soundsSystem.Play(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.FaceoffMusicVolume, delay);
+                            _ = _soundsSystem.PlayAsync(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.FaceoffMusicVolume, delay);
                         }
                         break;
 

--- a/Sounds/Sounds.cs
+++ b/Sounds/Sounds.cs
@@ -152,6 +152,11 @@ namespace oomtm450PuckMod_Sounds {
         /// </summary>
         private static string _currentMusicPlaying = "";
 
+        /// <summary>
+        /// String, current music type playing.
+        /// </summary>
+        private static string _currentMusicPlayingType = "";
+
         // Client-side.
         private static readonly LockList<string> _extraSoundsToLoad = new LockList<string>();
         #endregion
@@ -170,51 +175,51 @@ namespace oomtm450PuckMod_Sounds {
                         return true;
 
                     if (newGameState.Phase == GamePhase.BlueScore) {
-                        _currentMusicPlaying = Codebase.SoundsSystem.BLUE_GOAL_MUSIC;
+                        _currentMusicPlayingType = _currentMusicPlaying = Codebase.SoundsSystem.BLUE_GOAL_MUSIC;
                         string donorSong = DonorPrefs.GetSong(_lastGoalScorerSteamId);
-                        NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.PLAY_SOUND, SoundsSystem.FormatSoundStrForCommunication(_currentMusicPlaying, donorSong), Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
+                        NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.PLAY_SOUND, SoundsSystem.FormatSoundStrForCommunication(_currentMusicPlayingType, donorSong), Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
                     }
                     else if (newGameState.Phase == GamePhase.RedScore) {
-                        _currentMusicPlaying = Codebase.SoundsSystem.RED_GOAL_MUSIC;
+                        _currentMusicPlayingType = _currentMusicPlaying = Codebase.SoundsSystem.RED_GOAL_MUSIC;
                         string donorSong = DonorPrefs.GetSong(_lastGoalScorerSteamId);
-                        NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.PLAY_SOUND, SoundsSystem.FormatSoundStrForCommunication(_currentMusicPlaying, donorSong), Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
+                        NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.PLAY_SOUND, SoundsSystem.FormatSoundStrForCommunication(_currentMusicPlayingType, donorSong), Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
                     }
                     else if (newGameState.Phase == GamePhase.Intermission) {
-                        _currentMusicPlaying = Codebase.SoundsSystem.BETWEEN_PERIODS_MUSIC;
-                        NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.PLAY_SOUND, SoundsSystem.FormatSoundStrForCommunication(_currentMusicPlaying), Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
+                        _currentMusicPlayingType = _currentMusicPlaying = Codebase.SoundsSystem.BETWEEN_PERIODS_MUSIC;
+                        NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.PLAY_SOUND, SoundsSystem.FormatSoundStrForCommunication(_currentMusicPlayingType), Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
                     }
                     else if (!_changedPhase) {
                         if (newGameState.Phase == GamePhase.GameOver) {
                             NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.STOP_SOUND, Codebase.SoundsSystem.ALL, Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
                             NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.PLAY_SOUND, SoundsSystem.FormatSoundStrForCommunication(Codebase.SoundsSystem.GAMEOVER_MUSIC), Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
-                            _currentMusicPlaying = Codebase.SoundsSystem.GAMEOVER_MUSIC;
+                            _currentMusicPlayingType = _currentMusicPlaying = Codebase.SoundsSystem.GAMEOVER_MUSIC;
                         }
                         else if (newGameState.Phase == GamePhase.Warmup) {
                             NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.STOP_SOUND, Codebase.SoundsSystem.ALL, Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
                             NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.PLAY_SOUND, SoundsSystem.FormatSoundStrForCommunication(Codebase.SoundsSystem.WARMUP_MUSIC), Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
-                            _currentMusicPlaying = Codebase.SoundsSystem.WARMUP_MUSIC;
+                            _currentMusicPlayingType = _currentMusicPlaying = Codebase.SoundsSystem.WARMUP_MUSIC;
                         }
-                        else if (string.IsNullOrEmpty(_currentMusicPlaying) || _currentMusicPlaying == Codebase.SoundsSystem.WARMUP_MUSIC) {
+                        else if (string.IsNullOrEmpty(_currentMusicPlayingType) || _currentMusicPlayingType == Codebase.SoundsSystem.WARMUP_MUSIC) {
                             NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.STOP_SOUND, Codebase.SoundsSystem.ALL, Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
 
                             if (newGameState.Phase == GamePhase.FaceOff) {
                                 if (!_hasPlayedLastMinuteMusic && GameManager.Instance.Tick <= 60 && GameManager.Instance.Period == 3) {
                                     _hasPlayedLastMinuteMusic = true;
-                                    _currentMusicPlaying = Codebase.SoundsSystem.LAST_MINUTE_MUSIC;
+                                    _currentMusicPlayingType = Codebase.SoundsSystem.LAST_MINUTE_MUSIC;
                                 }
                                 else if (!_hasPlayedFirstFaceoffMusic) {
                                     _hasPlayedFirstFaceoffMusic = true;
-                                    _currentMusicPlaying = Codebase.SoundsSystem.FIRST_FACEOFF_MUSIC;
+                                    _currentMusicPlayingType = Codebase.SoundsSystem.FIRST_FACEOFF_MUSIC;
                                 }
                                 else if (!_hasPlayedSecondFaceoffMusic) {
                                     _hasPlayedSecondFaceoffMusic = true;
-                                    _currentMusicPlaying = Codebase.SoundsSystem.SECOND_FACEOFF_MUSIC;
+                                    _currentMusicPlayingType = Codebase.SoundsSystem.SECOND_FACEOFF_MUSIC;
                                 }
                                 else
-                                    _currentMusicPlaying = Codebase.SoundsSystem.FACEOFF_MUSIC;
+                                    _currentMusicPlayingType = Codebase.SoundsSystem.FACEOFF_MUSIC;
 
-                                NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.PLAY_SOUND, SoundsSystem.FormatSoundStrForCommunication(_currentMusicPlaying), Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
-                                _currentMusicPlaying = Codebase.SoundsSystem.FACEOFF_MUSIC;
+                                NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.PLAY_SOUND, SoundsSystem.FormatSoundStrForCommunication(_currentMusicPlayingType), Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
+                                _currentMusicPlayingType = _currentMusicPlaying = Codebase.SoundsSystem.FACEOFF_MUSIC;
                             }
                         }
                     }
@@ -236,6 +241,7 @@ namespace oomtm450PuckMod_Sounds {
                     if (newGameState.Phase == GamePhase.Play) {
                         NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.STOP_SOUND, Codebase.SoundsSystem.MUSIC, Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
                         _currentMusicPlaying = "";
+                        _currentMusicPlayingType = "";
                         _lastGoalScorerSteamId = "";
                         return;
                     }
@@ -261,6 +267,7 @@ namespace oomtm450PuckMod_Sounds {
                     // Reset music.
                     NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.STOP_SOUND, Codebase.SoundsSystem.MUSIC, Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
                     _currentMusicPlaying = "";
+                    _currentMusicPlayingType = "";
                     _hasPlayedLastMinuteMusic = false;
                     _hasPlayedFirstFaceoffMusic = false;
                     _hasPlayedSecondFaceoffMusic = false;
@@ -701,6 +708,7 @@ namespace oomtm450PuckMod_Sounds {
                 if (_soundsSystem != null) {
                     _soundsSystem.StopAll();
                     _currentMusicPlaying = "";
+                    _currentMusicPlayingType = "";
 
                     _soundsSystem.DestroyGameObjects();
                     _soundsSystem = null;
@@ -779,6 +787,7 @@ namespace oomtm450PuckMod_Sounds {
                             else if (value == Codebase.SoundsSystem.MUSIC) {
                                 NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.STOP_SOUND, Codebase.SoundsSystem.MUSIC, Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
                                 _currentMusicPlaying = "";
+                                _currentMusicPlayingType = "";
                             }
                             break;
                     }
@@ -888,9 +897,10 @@ namespace oomtm450PuckMod_Sounds {
                 if (_soundsSystem == null)
                     return;
 
-                if (!string.IsNullOrEmpty(_currentMusicPlaying)) {
-                    _soundsSystem.Stop(_currentMusicPlaying);
+                if (!string.IsNullOrEmpty(_currentMusicPlayingType)) {
+                    _soundsSystem.Stop(_currentMusicPlayingType);
                     _currentMusicPlaying = "";
+                    _currentMusicPlayingType = "";
                 }
 
                 _soundsSystem.DestroyGameObjects();
@@ -1043,6 +1053,8 @@ namespace oomtm450PuckMod_Sounds {
                         else
                             _currentMusicPlaying = chosenSound = playSoundDataStrSplitted[1];
 
+                        _currentMusicPlayingType = playSoundDataStrSplitted[0];
+
                         bool isFaceoffMusic = false;
                         float delay = 0;
                         if (playSoundDataStrSplitted[0] == Codebase.SoundsSystem.FACEOFF_MUSIC) {
@@ -1056,26 +1068,31 @@ namespace oomtm450PuckMod_Sounds {
                             if (string.IsNullOrEmpty(chosenSound))
                                 _currentMusicPlaying = SoundsSystem.GetRandomSound(_soundsSystem.BlueGoalMusicList, SoundsSystem.SoundType.BlueGoal, seed);
 
+                            _currentMusicPlayingType = Codebase.SoundsSystem.MUSIC;
                             _ = _soundsSystem.PlayAsync(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.GoalMusicVolume, 2.25f);
                         }
                         else if (playSoundDataStrSplitted[0] == Codebase.SoundsSystem.RED_GOAL_MUSIC) {
                             if (string.IsNullOrEmpty(chosenSound))
                                 _currentMusicPlaying = SoundsSystem.GetRandomSound(_soundsSystem.RedGoalMusicList, SoundsSystem.SoundType.RedGoal, seed);
 
+                            _currentMusicPlayingType = Codebase.SoundsSystem.MUSIC;
                             _ = _soundsSystem.PlayAsync(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.GoalMusicVolume, 2.25f);
                         }
                         else if (playSoundDataStrSplitted[0] == Codebase.SoundsSystem.BETWEEN_PERIODS_MUSIC) {
                             if (string.IsNullOrEmpty(chosenSound))
                                 _currentMusicPlaying = SoundsSystem.GetRandomSound(_soundsSystem.BetweenPeriodsMusicList, SoundsSystem.SoundType.BetweenPeriods, seed);
 
+                            _currentMusicPlayingType = Codebase.SoundsSystem.MUSIC;
                             _ = _soundsSystem.PlayAsync(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.BetweenPeriodsMusicVolume, 1.5f);
                         }
                         else if (playSoundDataStrSplitted[0] == Codebase.SoundsSystem.WARMUP_MUSIC) {
                             if (string.IsNullOrEmpty(chosenSound))
                                 _currentMusicPlaying = SoundsSystem.GetRandomSound(_soundsSystem.WarmupMusicList, SoundsSystem.SoundType.Warmup, seed);
 
-                            if (ClientConfig.WarmupMusic)
+                            if (ClientConfig.WarmupMusic) {
+                                _currentMusicPlayingType = Codebase.SoundsSystem.MUSIC;
                                 _ = _soundsSystem.PlayAsync(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.WarmupMusicVolume, 0, true);
+                            }
                         }
                         else if (playSoundDataStrSplitted[0] == Codebase.SoundsSystem.LAST_MINUTE_MUSIC) {
                             if (string.IsNullOrEmpty(chosenSound))
@@ -1120,6 +1137,7 @@ namespace oomtm450PuckMod_Sounds {
                             if (string.IsNullOrEmpty(chosenSound))
                                 _currentMusicPlaying = SoundsSystem.GetRandomSound(_soundsSystem.GameOverMusicList, SoundsSystem.SoundType.None, seed);
 
+                            _currentMusicPlayingType = Codebase.SoundsSystem.MUSIC;
                             _ = _soundsSystem.PlayAsync(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.GameOverMusicVolume, 0.5f);
                         }
                         else if (playSoundDataStrSplitted[0] == Codebase.SoundsSystem.WHISTLE)
@@ -1128,6 +1146,8 @@ namespace oomtm450PuckMod_Sounds {
                         if (isFaceoffMusic) {
                             if (string.IsNullOrEmpty(_currentMusicPlaying))
                                 _currentMusicPlaying = SoundsSystem.GetRandomSound(_soundsSystem.FaceoffMusicList, SoundsSystem.SoundType.Faceoff, seed);
+
+                            _currentMusicPlayingType = Codebase.SoundsSystem.MUSIC;
                             _ = _soundsSystem.PlayAsync(_currentMusicPlaying, Codebase.SoundsSystem.MUSIC, ClientConfig.MusicVolume * ClientConfig.FaceoffMusicVolume, delay);
                         }
                         break;
@@ -1148,13 +1168,14 @@ namespace oomtm450PuckMod_Sounds {
                         _soundsSystem.Warnings.Clear();
 
                         if (dataStr == Codebase.SoundsSystem.MUSIC) {
-                            if (!string.IsNullOrEmpty(_currentMusicPlaying))
-                                _soundsSystem.Stop(_currentMusicPlaying);
+                            if (!string.IsNullOrEmpty(_currentMusicPlayingType))
+                                _soundsSystem.Stop(_currentMusicPlayingType);
                         }
                         else if (dataStr == Codebase.SoundsSystem.ALL)
                             _soundsSystem.StopAll();
 
                         _currentMusicPlaying = "";
+                        _currentMusicPlayingType = "";
                         break;
 
                     case Codebase.SoundsSystem.LOAD_EXTRA_SOUNDS:
@@ -1177,21 +1198,21 @@ namespace oomtm450PuckMod_Sounds {
 
             if (!_hasPlayedLastMinuteMusic && GameManager.Instance.Tick <= 60 && GameManager.Instance.GameState.Value.Period == 3) {
                 _hasPlayedLastMinuteMusic = true;
-                _currentMusicPlaying = Codebase.SoundsSystem.LAST_MINUTE_MUSIC_DELAYED;
+                _currentMusicPlayingType = Codebase.SoundsSystem.LAST_MINUTE_MUSIC_DELAYED;
             }
             else if (!_hasPlayedFirstFaceoffMusic) {
                 _hasPlayedFirstFaceoffMusic = true;
-                _currentMusicPlaying = Codebase.SoundsSystem.FIRST_FACEOFF_MUSIC_DELAYED;
+                _currentMusicPlayingType = Codebase.SoundsSystem.FIRST_FACEOFF_MUSIC_DELAYED;
             }
             else if (!_hasPlayedSecondFaceoffMusic) {
                 _hasPlayedSecondFaceoffMusic = true;
-                _currentMusicPlaying = Codebase.SoundsSystem.SECOND_FACEOFF_MUSIC_DELAYED;
+                _currentMusicPlayingType = Codebase.SoundsSystem.SECOND_FACEOFF_MUSIC_DELAYED;
             }
             else
-                _currentMusicPlaying = Codebase.SoundsSystem.FACEOFF_MUSIC_DELAYED;
+                _currentMusicPlayingType = Codebase.SoundsSystem.FACEOFF_MUSIC_DELAYED;
 
-            NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.PLAY_SOUND, SoundsSystem.FormatSoundStrForCommunication(_currentMusicPlaying), Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
-            _currentMusicPlaying = Codebase.SoundsSystem.FACEOFF_MUSIC;
+            NetworkCommunication.SendDataToAll(Codebase.SoundsSystem.PLAY_SOUND, SoundsSystem.FormatSoundStrForCommunication(_currentMusicPlayingType), Constants.FROM_SERVER_TO_CLIENT, ServerConfig);
+            _currentMusicPlayingType = _currentMusicPlaying = Codebase.SoundsSystem.FACEOFF_MUSIC;
         }
 
         /// <summary>

--- a/Sounds/SoundsSystem.cs
+++ b/Sounds/SoundsSystem.cs
@@ -425,8 +425,8 @@ namespace oomtm450PuckMod_Sounds {
                 audioSource.PlayDelayed(delay);
         }
 
-        internal void Stop(string name) {
-            if (string.IsNullOrEmpty(name) || !_soundObjects.TryGetValue(name, out GameObject soundObject))
+        internal void Stop(string type) {
+            if (string.IsNullOrEmpty(type) || !_soundObjects.TryGetValue(type, out GameObject soundObject))
                 return;
             soundObject.GetComponent<AudioSource>().Stop();
         }

--- a/Sounds/SoundsSystem.cs
+++ b/Sounds/SoundsSystem.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Networking;
+using static Humanizer.In;
 using static oomtm450PuckMod_Sounds.SoundsSystem;
 
 namespace oomtm450PuckMod_Sounds {
@@ -196,75 +197,6 @@ namespace oomtm450PuckMod_Sounds {
 
             await Awaitable.MainThreadAsync();
 
-            foreach (string file in files) {
-                string filePath = new Uri(Path.GetFullPath(file)).LocalPath;
-                if (Path.GetExtension(filePath).ToLowerInvariant() != SOUND_EXTENSION) {
-                    await Awaitable.NextFrameAsync(cancellationToken);
-                    continue;
-                }
-
-                using (UnityWebRequest webRequest = UnityWebRequestMultimedia.GetAudioClip(filePath, AudioType.OGGVORBIS)) {
-                    DownloadHandlerAudioClip downloadHandler = (DownloadHandlerAudioClip)webRequest.downloadHandler;
-
-                    downloadHandler.streamAudio = true;
-
-                    var asyncOp = webRequest.SendWebRequest();
-
-                    while (!asyncOp.isDone) {
-                        if (cancellationToken.IsCancellationRequested) {
-                            await Awaitable.BackgroundThreadAsync();
-                            IsLoading = false;
-                            await Awaitable.MainThreadAsync();
-                            return;
-                        }
-
-                        await Awaitable.WaitForSecondsAsync(0.1f, cancellationToken);
-                    }
-
-                    if (webRequest.result != UnityWebRequest.Result.Success)
-                        Warnings.Add(webRequest.error);
-                    else {
-                        try {
-                            AudioClip clip = downloadHandler.audioClip;
-
-                            if (!clip) {
-                                Errors.Add($"Sounds.{nameof(GetAudioClipsAsync)} clip null.");
-                                continue;
-                            }
-
-                            clip.name = filePath.Substring(filePath.LastIndexOf('\\') + 1, filePath.Length - filePath.LastIndexOf('\\') - 1).Replace(SOUND_EXTENSION, "");
-
-                            if (!currentConfig.TryGetValue(clip.name, out SoundSettings clipSettings)) {
-                                clipSettings = new SoundSettings {
-                                    Weight = DEFAULT_SOUND_WEIGHT,
-                                    Volume = DEFAULT_SOUND_VOLUME,
-                                    Delay = DEFAULT_SOUND_DELAY,
-                                };
-                                currentConfig.Add(clip.name, clipSettings);
-                            }
-
-                            if (clipSettings.Weight <= 0)
-                                continue;
-
-                            DontDestroyOnLoad(clip);
-                            _audioClips.Add(clip);
-
-                            AddClipNameToCorrectList(clip.name, (int)clipSettings.Weight);
-                        }
-                        catch (Exception ex) {
-                            Errors.Add($"Sounds.{nameof(GetAudioClipsAsync)} 3 : {ex}");
-
-                            await Awaitable.BackgroundThreadAsync();
-                            IsLoading = false;
-                            await Awaitable.MainThreadAsync();
-                            return;
-                        }
-                    }
-                }
-
-                await Awaitable.NextFrameAsync(cancellationToken);
-            }
-
             try {
                 foreach (string key in currentConfig.Keys)
                     _soundSettings.AddOrUpdate(key, currentConfig[key]);
@@ -274,6 +206,11 @@ namespace oomtm450PuckMod_Sounds {
             }
             catch (Exception ex) {
                 Warnings.Add($"Sounds.{nameof(GetAudioClipsAsync)} 4 : {ex}");
+            }
+
+            foreach (string file in files) {
+                await CreateAudioClipAsync(file, cancellationToken);
+                await Awaitable.NextFrameAsync(cancellationToken);
             }
 
             try {
@@ -297,6 +234,114 @@ namespace oomtm450PuckMod_Sounds {
             await Awaitable.MainThreadAsync();
         }
 
+        private async Awaitable CreateAudioClipAsync(string file, CancellationToken cancellationToken = default) {
+            await Awaitable.MainThreadAsync();
+
+            string filePath = new Uri(Path.GetFullPath(file)).LocalPath;
+            if (Path.GetExtension(filePath).ToLowerInvariant() != SOUND_EXTENSION) {
+                await Awaitable.NextFrameAsync(cancellationToken);
+                return;
+            }
+
+            string clipName = filePath.Substring(filePath.LastIndexOf('\\') + 1, filePath.Length - filePath.LastIndexOf('\\') - 1).Replace(SOUND_EXTENSION, "");
+
+            if (!_soundSettings.TryGetValue(clipName, out SoundSettings clipSettings)) {
+                clipSettings = new SoundSettings {
+                    Weight = DEFAULT_SOUND_WEIGHT,
+                    Volume = DEFAULT_SOUND_VOLUME,
+                    Delay = DEFAULT_SOUND_DELAY,
+                    FilePath = filePath,
+                };
+                _soundSettings.Add(clipName, clipSettings);
+            }
+            else {
+                if (clipSettings.Weight <= 0)
+                    return;
+
+                clipSettings.FilePath = filePath;
+            }
+
+            AddClipNameToCorrectList(clipName, (int)clipSettings.Weight);
+
+            if (!AudioHasToBePreloaded(clipName))
+                return;
+
+            await WebRequestAudioClipAsync(clipName, clipSettings.FilePath, cancellationToken);
+        }
+
+        private async Awaitable WebRequestAudioClipAsync(string clipName, string filePath, CancellationToken cancellationToken = default) {
+            await Awaitable.MainThreadAsync();
+
+            using (UnityWebRequest webRequest = UnityWebRequestMultimedia.GetAudioClip(filePath, AudioType.OGGVORBIS)) {
+                DownloadHandlerAudioClip downloadHandler = (DownloadHandlerAudioClip)webRequest.downloadHandler;
+
+                downloadHandler.streamAudio = true;
+
+                var asyncOp = webRequest.SendWebRequest();
+
+                while (!asyncOp.isDone) {
+                    if (cancellationToken.IsCancellationRequested) {
+                        await Awaitable.BackgroundThreadAsync();
+                        IsLoading = false;
+                        await Awaitable.MainThreadAsync();
+                        return;
+                    }
+
+                    await Awaitable.WaitForSecondsAsync(0.1f, cancellationToken);
+                }
+
+                if (webRequest.result != UnityWebRequest.Result.Success)
+                    Warnings.Add(webRequest.error);
+                else {
+                    try {
+                        AudioClip clip = downloadHandler.audioClip;
+
+                        if (!clip) {
+                            Errors.Add($"Sounds.{nameof(GetAudioClipsAsync)} clip null {clipName}.");
+                            RemoveClip(clipName);
+                            return;
+                        }
+
+                        clip.name = clipName;
+
+                        DontDestroyOnLoad(clip);
+                        _audioClips.Add(clip);
+                    }
+                    catch (Exception ex) {
+                        Errors.Add($"Sounds.{nameof(GetAudioClipsAsync)} 3 : {ex}");
+
+                        RemoveClip(clipName);
+
+                        await Awaitable.BackgroundThreadAsync();
+                        IsLoading = false;
+                        await Awaitable.MainThreadAsync();
+                        return;
+                    }
+                }
+            }
+        }
+
+        private void RemoveClip(string clipName) {
+            FaceoffMusicList.Remove(clipName);
+            BlueGoalMusicList.Remove(clipName);
+            RedGoalMusicList.Remove(clipName);
+            BetweenPeriodsMusicList.Remove(clipName);
+            WarmupMusicList.Remove(clipName);
+            LastMinuteMusicList.Remove(clipName);
+            FirstFaceoffMusicList.Remove(clipName);
+            SecondFaceoffMusicList.Remove(clipName);
+            GameOverMusicList.Remove(clipName);
+        }
+
+        private bool AudioHasToBePreloaded(string clipName) {
+            if (!Sounds.ClientConfig.LazyLoading)
+                return true;
+            if (clipName.Contains(Codebase.SoundsSystem.GOAL_HORN))
+                return true;
+
+            return false;
+        }
+
         private void AddClipNameToCorrectList(string clipName, int weight = DEFAULT_SOUND_WEIGHT) {
             if (clipName.Contains(Codebase.SoundsSystem.FACEOFF_MUSIC))
                 FaceoffMusicList.Add(clipName, weight);
@@ -318,28 +363,12 @@ namespace oomtm450PuckMod_Sounds {
                 GameOverMusicList.Add(clipName, weight);
         }
 
-        internal void Play(string name, string type, float vol = float.MaxValue, float delay = 0, bool loop = false) {
+        internal async Awaitable PlayAsync(string name, string type, float vol = float.MaxValue, float delay = 0, bool loop = false) {
             if (string.IsNullOrEmpty(name))
                 return;
 
             if (type == Codebase.SoundsSystem.MUSIC && !Sounds.ClientConfig.Music)
                 return;
-
-            if (!_soundObjects.TryGetValue(name, out GameObject soundObject)) {
-                AudioClip clip = _audioClips.FirstOrDefault(x => x.name == name);
-                if (clip == null)
-                    return;
-
-                soundObject = new GameObject(name);
-                DontDestroyOnLoad(soundObject);
-                soundObject.AddComponent<AudioSource>();
-                soundObject.GetComponent<AudioSource>().clip = clip;
-                DontDestroyOnLoad(soundObject.GetComponent<AudioSource>());
-                _soundObjects.Add(name, soundObject);
-            }
-
-            AudioSource audioSource = soundObject.GetComponent<AudioSource>();
-            audioSource.loop = loop;
 
             SoundSettings soundSettings = null;
             float volModifier = DEFAULT_SOUND_VOLUME;
@@ -348,6 +377,30 @@ namespace oomtm450PuckMod_Sounds {
                 volModifier = (float)soundSettings.Volume;
                 delayModifier = (float)soundSettings.Delay;
             }
+            else
+                return;
+
+            AudioClip clip = _audioClips.FirstOrDefault(x => x.name == name);
+            if (clip == null) {
+                if (!Sounds.ClientConfig.LazyLoading)
+                    return;
+
+                await WebRequestAudioClipAsync(name, soundSettings.FilePath);
+                clip = _audioClips.FirstOrDefault(x => x.name == name);
+                if (clip == null)
+                    return;
+            }
+
+            if (!_soundObjects.TryGetValue(type, out GameObject soundObject)) {
+                soundObject = new GameObject(type);
+                DontDestroyOnLoad(soundObject);
+                DontDestroyOnLoad(soundObject.AddComponent<AudioSource>());
+                _soundObjects.Add(type, soundObject);
+            }
+
+            AudioSource audioSource = soundObject.GetComponent<AudioSource>();
+            audioSource.clip = clip;
+            audioSource.loop = loop;
 
             vol *= volModifier;
             audioSource.volume = vol;
@@ -457,11 +510,11 @@ namespace oomtm450PuckMod_Sounds {
                 if (blueGoalAudioSource == null || redGoalAudioSource == null)
                     return;
 
-                blueGoalAudioSource.clip = _audioClips.FirstOrDefault(x => x.name.Contains(Codebase.SoundsSystem.REDGOALHORN));
+                blueGoalAudioSource.clip = _audioClips.FirstOrDefault(x => x.name.Contains(Codebase.SoundsSystem.RED_GOAL_HORN));
                 blueGoalAudioSource.maxDistance = 400f;
                 DEFAULT_HORN_VOLUME = blueGoalAudioSource.volume;
                 
-                redGoalAudioSource.clip = _audioClips.FirstOrDefault(x => x.name.Contains(Codebase.SoundsSystem.BLUEGOALHORN));
+                redGoalAudioSource.clip = _audioClips.FirstOrDefault(x => x.name.Contains(Codebase.SoundsSystem.BLUE_GOAL_HORN));
                 redGoalAudioSource.maxDistance = 400f;
 
                 ChangeHornsVolume(Sounds.ClientConfig.HornVolume, new List<AudioSource> { blueGoalAudioSource, redGoalAudioSource, });
@@ -574,6 +627,9 @@ namespace oomtm450PuckMod_Sounds {
             public int? Weight { get; set; } = DEFAULT_SOUND_WEIGHT;
 
             public float? Delay { get; set; } = DEFAULT_SOUND_DELAY;
+
+            [JsonIgnore]
+            public string FilePath { get; set; } = "";
         }
 
         internal enum SoundType {


### PR DESCRIPTION
**Sounds**
Added lazy loading setting (on by default). This setting makes the Sounds mod load sounds on the first play attempt, then caches it.
To preload all sounds, set LazyLoading to false in the client settings (config > oomtm450_sounds_clientconfig.json).
Lazy loading still preloads all goal horns due to timing issues.

Removed unused setting.
Removed game object per sound for game object per type. (Optimization)